### PR TITLE
Add Order Ledger API Support for Payment Tracking

### DIFF
--- a/example/orderledger/main.go
+++ b/example/orderledger/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	walmart "github.com/eshaffer321/walmart-client"
+)
+
+func main() {
+	// Initialize the client with your saved cookies
+	config := walmart.ClientConfig{
+		CookieFile: "cookies.json", // Path to your cookie file
+		RateLimit:  time.Second,
+		AutoSave:   true,
+	}
+
+	client, err := walmart.NewWalmartClient(config)
+	if err != nil {
+		log.Fatal("Failed to create client:", err)
+	}
+
+	// Example order ID - replace with your actual order ID
+	orderID := "200013509224581"
+
+	// Get the order ledger showing actual credit card charges
+	ledger, err := client.GetOrderLedger(orderID)
+	if err != nil {
+		log.Fatal("Failed to get order ledger:", err)
+	}
+
+	// Display the ledger information
+	fmt.Printf("Order Ledger for Order #%s\n", ledger.OrderID)
+	fmt.Println("=" + string(make([]byte, 50)))
+
+	var grandTotal float64
+	for _, pm := range ledger.PaymentMethods {
+		fmt.Printf("\nPayment Method: %s - %s", pm.CardType, pm.PaymentType)
+		if pm.LastFour != "" {
+			fmt.Printf(" (ending in %s)", pm.LastFour)
+		}
+		fmt.Println()
+
+		fmt.Println("Final Charges:")
+		for i, charge := range pm.FinalCharges {
+			if charge >= 0 {
+				fmt.Printf("  Charge %d: $%.2f\n", i+1, charge)
+			} else {
+				fmt.Printf("  Refund %d: -$%.2f\n", i+1, -charge)
+			}
+		}
+
+		fmt.Printf("  Total for this card: $%.2f\n", pm.TotalCharged)
+		grandTotal += pm.TotalCharged
+	}
+
+	fmt.Println("=" + string(make([]byte, 50)))
+	fmt.Printf("Grand Total: $%.2f\n", grandTotal)
+
+	// Example usage for matching with bank transactions
+	fmt.Println("\n--- Bank Transaction Matching ---")
+	fmt.Println("To match with your bank statement, look for:")
+
+	for _, pm := range ledger.PaymentMethods {
+		if pm.PaymentType == "CREDITCARD" {
+			fmt.Printf("\n%s", pm.CardType)
+			if pm.LastFour != "" {
+				fmt.Printf(" ending in %s:\n", pm.LastFour)
+			} else {
+				fmt.Println(":")
+			}
+
+			for _, charge := range pm.FinalCharges {
+				if charge > 0 {
+					fmt.Printf("  - A charge of $%.2f\n", charge)
+				}
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/eshaffer321/walmart-client
 
 go 1.20
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/orderledger.go
+++ b/orderledger.go
@@ -1,0 +1,171 @@
+package walmart
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// OrderLedger represents simplified order payment information
+type OrderLedger struct {
+	OrderID        string                   `json:"orderId"`
+	PaymentMethods []PaymentMethodCharges   `json:"paymentMethods"`
+}
+
+// PaymentMethodCharges contains the final charges for a payment method
+type PaymentMethodCharges struct {
+	PaymentType  string    `json:"paymentType"`  // "CREDITCARD", "GIFTCARD"
+	CardType     string    `json:"cardType"`      // "VISA", "WMTRC", etc.
+	LastFour     string    `json:"lastFour"`      // Last 4 digits of card
+	FinalCharges []float64 `json:"finalCharges"`  // Individual charge amounts
+	TotalCharged float64   `json:"totalCharged"`  // Sum of final charges
+}
+
+// OrderLedgerResponse represents the raw API response
+type OrderLedgerResponse struct {
+	Data struct {
+		GetOrderLedger struct {
+			PaymentMethodsLedgers []PaymentMethodLedger `json:"paymentMethodsLedgers"`
+		} `json:"getOrderLedger"`
+	} `json:"data"`
+}
+
+// PaymentMethodLedger represents a payment method's transaction history
+type PaymentMethodLedger struct {
+	PaymentType  string        `json:"paymentType"`  // "CREDITCARD", "GIFTCARD"
+	CardType     string        `json:"cardType"`      // "VISA", "WMTRC"
+	Description  string        `json:"description"`   // "Ending in 0953"
+	Transactions []Transaction `json:"transactions"`
+}
+
+// Transaction represents a group of charges by type
+type Transaction struct {
+	ChargeType       string            `json:"chargeType"` // "FINAL_CHARGES", "TEMPORARY_HOLDS"
+	TransactionLines []TransactionLine `json:"transactionLines"`
+}
+
+// TransactionLine represents transactions on a specific date
+type TransactionLine struct {
+	Date     string    `json:"date"`
+	RowLines []RowLine `json:"rowLines"`
+}
+
+// RowLine represents an individual transaction entry
+type RowLine struct {
+	LineType      string   `json:"lineType"`      // "ORDER_CHARGE", "ORDER_ADJUSTMENT_REFUND", etc.
+	DisplayValues []string `json:"displayValues"` // ["$178.96"], ["$4.12"]
+	Time          string   `json:"time"`
+}
+
+// GetOrderLedger fetches the payment ledger for an order showing actual charges
+func (c *WalmartClient) GetOrderLedger(orderID string) (*OrderLedger, error) {
+	if orderID == "" {
+		return nil, fmt.Errorf("order ID is required")
+	}
+
+	// Use the hash from the provided URL
+	const ledgerHash = "1234d48bfc5e62b608c0dae2c5752f31978870456bcf0023bad3988009e70919"
+
+	url := fmt.Sprintf("https://www.walmart.com/orchestra/orders/graphql/getOrderLedger/%s?variables={\"orderId\":\"%s\"}",
+		ledgerHash, orderID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Set headers using the client's cookie management
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var ledgerResp OrderLedgerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ledgerResp); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	// Convert to simplified structure
+	return convertToOrderLedger(orderID, ledgerResp), nil
+}
+
+// convertToOrderLedger converts the raw API response to a simplified structure
+func convertToOrderLedger(orderID string, resp OrderLedgerResponse) *OrderLedger {
+	ledger := &OrderLedger{
+		OrderID:        orderID,
+		PaymentMethods: []PaymentMethodCharges{},
+	}
+
+	for _, pm := range resp.Data.GetOrderLedger.PaymentMethodsLedgers {
+		charges := PaymentMethodCharges{
+			PaymentType:  pm.PaymentType,
+			CardType:     pm.CardType,
+			LastFour:     extractLastFour(pm.Description),
+			FinalCharges: []float64{},
+		}
+
+		// Extract final charges only
+		for _, transaction := range pm.Transactions {
+			if transaction.ChargeType == "FINAL_CHARGES" {
+				for _, line := range transaction.TransactionLines {
+					for _, row := range line.RowLines {
+						// Process all display values for this row
+						for _, value := range row.DisplayValues {
+							if amount, err := parseAmount(value); err == nil {
+								charges.FinalCharges = append(charges.FinalCharges, amount)
+								charges.TotalCharged += amount
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Only add payment methods that have charges
+		if len(charges.FinalCharges) > 0 {
+			ledger.PaymentMethods = append(ledger.PaymentMethods, charges)
+		}
+	}
+
+	return ledger
+}
+
+// parseAmount parses a money string like "$178.96" or "-$15.00" to float64
+func parseAmount(s string) (float64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty amount string")
+	}
+
+	// Remove dollar sign and commas
+	cleaned := strings.ReplaceAll(s, "$", "")
+	cleaned = strings.ReplaceAll(cleaned, ",", "")
+	cleaned = strings.TrimSpace(cleaned)
+
+	amount, err := strconv.ParseFloat(cleaned, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing amount %q: %w", s, err)
+	}
+
+	return amount, nil
+}
+
+// extractLastFour extracts the last four digits from descriptions like "Ending in 0953"
+func extractLastFour(description string) string {
+	// Case-insensitive regex to match "ending in XXXX"
+	re := regexp.MustCompile(`(?i)ending\s+in\s+(\d{4})`)
+	matches := re.FindStringSubmatch(description)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
+}

--- a/orderledger_test.go
+++ b/orderledger_test.go
@@ -1,0 +1,585 @@
+package walmart
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testTransport redirects requests to our test server
+type testTransport struct {
+	serverURL string
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the host with our test server
+	testURL, _ := url.Parse(t.serverURL)
+	req.URL.Host = testURL.Host
+	req.URL.Scheme = testURL.Scheme
+
+	// Use default transport for actual request
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestGetOrderLedger(t *testing.T) {
+	tests := []struct {
+		name           string
+		orderID        string
+		mockResponse   string
+		expectedLedger *OrderLedger
+		wantErr        bool
+		errMessage     string
+	}{
+		{
+			name:    "successful ledger retrieval with credit card and walmart cash",
+			orderID: "200013509224581",
+			mockResponse: `{
+				"data": {
+					"getOrderLedger": {
+						"paymentMethodsLedgers": [
+							{
+								"paymentType": "CREDITCARD",
+								"cardType": "VISA",
+								"description": "Ending in 0953",
+								"transactions": [
+									{
+										"chargeType": "FINAL_CHARGES",
+										"transactionLines": [
+											{
+												"date": "December 16, 2024",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$178.96"],
+														"time": "4:31 AM"
+													}
+												]
+											},
+											{
+												"date": "December 17, 2024",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$4.12"],
+														"time": "7:31 PM"
+													}
+												]
+											}
+										]
+									},
+									{
+										"chargeType": "TEMPORARY_HOLDS",
+										"transactionLines": [
+											{
+												"date": "December 16, 2024",
+												"rowLines": [
+													{
+														"lineType": "ORDER_AUTHORIZATION",
+														"displayValues": ["$185.83"],
+														"time": "3:41 AM"
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"paymentType": "GIFTCARD",
+								"cardType": "WMTRC",
+								"description": "Walmart Cash",
+								"transactions": [
+									{
+										"chargeType": "FINAL_CHARGES",
+										"transactionLines": [
+											{
+												"date": "December 16, 2024",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$2.75"],
+														"time": "4:31 AM"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			}`,
+			expectedLedger: &OrderLedger{
+				OrderID: "200013509224581",
+				PaymentMethods: []PaymentMethodCharges{
+					{
+						PaymentType:  "CREDITCARD",
+						CardType:     "VISA",
+						LastFour:     "0953",
+						FinalCharges: []float64{178.96, 4.12},
+						TotalCharged: 183.08,
+					},
+					{
+						PaymentType:  "GIFTCARD",
+						CardType:     "WMTRC",
+						LastFour:     "",
+						FinalCharges: []float64{2.75},
+						TotalCharged: 2.75,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "ledger with order adjustments and refunds",
+			orderID: "200013509224582",
+			mockResponse: `{
+				"data": {
+					"getOrderLedger": {
+						"paymentMethodsLedgers": [
+							{
+								"paymentType": "CREDITCARD",
+								"cardType": "MASTERCARD",
+								"description": "Ending in 1234",
+								"transactions": [
+									{
+										"chargeType": "FINAL_CHARGES",
+										"transactionLines": [
+											{
+												"date": "January 10, 2025",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$100.00"],
+														"time": "10:00 AM"
+													},
+													{
+														"lineType": "ORDER_ADJUSTMENT_REFUND",
+														"displayValues": ["-$15.00"],
+														"time": "11:00 AM"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			}`,
+			expectedLedger: &OrderLedger{
+				OrderID: "200013509224582",
+				PaymentMethods: []PaymentMethodCharges{
+					{
+						PaymentType:  "CREDITCARD",
+						CardType:     "MASTERCARD",
+						LastFour:     "1234",
+						FinalCharges: []float64{100.00, -15.00},
+						TotalCharged: 85.00,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "single credit card payment",
+			orderID: "200013509224583",
+			mockResponse: `{
+				"data": {
+					"getOrderLedger": {
+						"paymentMethodsLedgers": [
+							{
+								"paymentType": "CREDITCARD",
+								"cardType": "AMEX",
+								"description": "Ending in 5678",
+								"transactions": [
+									{
+										"chargeType": "FINAL_CHARGES",
+										"transactionLines": [
+											{
+												"date": "January 15, 2025",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$250.50"],
+														"time": "2:30 PM"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			}`,
+			expectedLedger: &OrderLedger{
+				OrderID: "200013509224583",
+				PaymentMethods: []PaymentMethodCharges{
+					{
+						PaymentType:  "CREDITCARD",
+						CardType:     "AMEX",
+						LastFour:     "5678",
+						FinalCharges: []float64{250.50},
+						TotalCharged: 250.50,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty ledger response",
+			orderID: "200013509224584",
+			mockResponse: `{
+				"data": {
+					"getOrderLedger": {
+						"paymentMethodsLedgers": []
+					}
+				}
+			}`,
+			expectedLedger: &OrderLedger{
+				OrderID:        "200013509224584",
+				PaymentMethods: []PaymentMethodCharges{},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid order ID",
+			orderID: "",
+			wantErr: true,
+			errMessage: "order ID is required",
+		},
+		{
+			name:    "malformed JSON response",
+			orderID: "200013509224585",
+			mockResponse: `{invalid json}`,
+			wantErr: true,
+		},
+		{
+			name:    "payment method without description",
+			orderID: "200013509224586",
+			mockResponse: `{
+				"data": {
+					"getOrderLedger": {
+						"paymentMethodsLedgers": [
+							{
+								"paymentType": "CREDITCARD",
+								"cardType": "DISCOVER",
+								"description": "",
+								"transactions": [
+									{
+										"chargeType": "FINAL_CHARGES",
+										"transactionLines": [
+											{
+												"date": "January 20, 2025",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$75.00"],
+														"time": "5:00 PM"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			}`,
+			expectedLedger: &OrderLedger{
+				OrderID: "200013509224586",
+				PaymentMethods: []PaymentMethodCharges{
+					{
+						PaymentType:  "CREDITCARD",
+						CardType:     "DISCOVER",
+						LastFour:     "",
+						FinalCharges: []float64{75.00},
+						TotalCharged: 75.00,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "multiple display values in single row line",
+			orderID: "200013509224587",
+			mockResponse: `{
+				"data": {
+					"getOrderLedger": {
+						"paymentMethodsLedgers": [
+							{
+								"paymentType": "CREDITCARD",
+								"cardType": "VISA",
+								"description": "Ending in 9999",
+								"transactions": [
+									{
+										"chargeType": "FINAL_CHARGES",
+										"transactionLines": [
+											{
+												"date": "January 25, 2025",
+												"rowLines": [
+													{
+														"lineType": "ORDER_CHARGE",
+														"displayValues": ["$50.00", "$25.00"],
+														"time": "6:00 PM"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			}`,
+			expectedLedger: &OrderLedger{
+				OrderID: "200013509224587",
+				PaymentMethods: []PaymentMethodCharges{
+					{
+						PaymentType:  "CREDITCARD",
+						CardType:     "VISA",
+						LastFour:     "9999",
+						FinalCharges: []float64{50.00, 25.00},
+						TotalCharged: 75.00,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "GET", r.Method)
+				assert.Contains(t, r.URL.Path, "/orchestra/orders/graphql/getOrderLedger/")
+
+				if tt.orderID != "" {
+					assert.Contains(t, r.URL.Query().Get("variables"), tt.orderID)
+				}
+
+				if tt.mockResponse != "" {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(tt.mockResponse))
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			config := ClientConfig{
+				RateLimit: time.Millisecond * 100,
+				AutoSave:  false,
+			}
+			client, err := NewWalmartClient(config)
+			require.NoError(t, err)
+
+			// Override the httpClient to use our test server
+			client.httpClient = &http.Client{
+				Transport: &testTransport{
+					serverURL: server.URL,
+				},
+			}
+
+			ledger, err := client.GetOrderLedger(tt.orderID)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMessage != "" {
+					assert.Contains(t, err.Error(), tt.errMessage)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedLedger, ledger)
+			}
+		})
+	}
+}
+
+func TestParseAmount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected float64
+		wantErr  bool
+	}{
+		{
+			name:     "positive amount with dollar sign",
+			input:    "$178.96",
+			expected: 178.96,
+			wantErr:  false,
+		},
+		{
+			name:     "negative amount with dollar sign",
+			input:    "-$15.00",
+			expected: -15.00,
+			wantErr:  false,
+		},
+		{
+			name:     "amount with comma separator",
+			input:    "$1,234.56",
+			expected: 1234.56,
+			wantErr:  false,
+		},
+		{
+			name:     "negative amount with comma",
+			input:    "-$1,000.00",
+			expected: -1000.00,
+			wantErr:  false,
+		},
+		{
+			name:     "zero amount",
+			input:    "$0.00",
+			expected: 0.00,
+			wantErr:  false,
+		},
+		{
+			name:     "amount without dollar sign",
+			input:    "100.50",
+			expected: 100.50,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid amount string",
+			input:    "invalid",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseAmount(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestExtractLastFour(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		expected    string
+	}{
+		{
+			name:        "standard ending in format",
+			description: "Ending in 0953",
+			expected:    "0953",
+		},
+		{
+			name:        "lowercase ending in",
+			description: "ending in 1234",
+			expected:    "1234",
+		},
+		{
+			name:        "mixed case",
+			description: "ENDING IN 5678",
+			expected:    "5678",
+		},
+		{
+			name:        "walmart cash description",
+			description: "Walmart Cash",
+			expected:    "",
+		},
+		{
+			name:        "empty description",
+			description: "",
+			expected:    "",
+		},
+		{
+			name:        "no ending in pattern",
+			description: "Credit Card",
+			expected:    "",
+		},
+		{
+			name:        "ending in with extra spaces",
+			description: "Ending  in  9999",
+			expected:    "9999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractLastFour(tt.description)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestOrderLedgerResponseUnmarshaling(t *testing.T) {
+	jsonData := `{
+		"data": {
+			"getOrderLedger": {
+				"paymentMethodsLedgers": [
+					{
+						"paymentType": "CREDITCARD",
+						"cardType": "VISA",
+						"description": "Ending in 0953",
+						"transactions": [
+							{
+								"chargeType": "FINAL_CHARGES",
+								"transactionLines": [
+									{
+										"date": "December 16, 2024",
+										"rowLines": [
+											{
+												"lineType": "ORDER_CHARGE",
+												"displayValues": ["$178.96"],
+												"time": "4:31 AM"
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		}
+	}`
+
+	var response OrderLedgerResponse
+	err := json.Unmarshal([]byte(jsonData), &response)
+	require.NoError(t, err)
+
+	ledgers := response.Data.GetOrderLedger.PaymentMethodsLedgers
+	require.Len(t, ledgers, 1)
+	assert.Equal(t, "CREDITCARD", ledgers[0].PaymentType)
+	assert.Equal(t, "VISA", ledgers[0].CardType)
+	assert.Equal(t, "Ending in 0953", ledgers[0].Description)
+
+	require.Len(t, ledgers[0].Transactions, 1)
+	assert.Equal(t, "FINAL_CHARGES", ledgers[0].Transactions[0].ChargeType)
+
+	require.Len(t, ledgers[0].Transactions[0].TransactionLines, 1)
+	assert.Equal(t, "December 16, 2024", ledgers[0].Transactions[0].TransactionLines[0].Date)
+
+	require.Len(t, ledgers[0].Transactions[0].TransactionLines[0].RowLines, 1)
+	rowLine := ledgers[0].Transactions[0].TransactionLines[0].RowLines[0]
+	assert.Equal(t, "ORDER_CHARGE", rowLine.LineType)
+	assert.Equal(t, []string{"$178.96"}, rowLine.DisplayValues)
+	assert.Equal(t, "4:31 AM", rowLine.Time)
+}


### PR DESCRIPTION
## Summary
- Implements `GetOrderLedger` method to fetch detailed payment information from Walmart's GraphQL API
- Enables accurate matching of Walmart orders to bank transactions
- Provides actual charge amounts rather than just order totals

## Key Features
✅ **Payment Method Breakdown**: Fetch final charges per payment method (credit card, Walmart Cash)
✅ **Split Charge Support**: Handle split charges when orders are modified  
✅ **Card Identification**: Extract last four digits for card matching
✅ **Refund Processing**: Support for adjustments and refunds
✅ **TDD Approach**: Comprehensive test coverage with 8+ test scenarios

## Implementation Details

### New Files
- `orderledger.go`: Core implementation with data structures and API method
- `orderledger_test.go`: Complete test suite covering all edge cases  
- `example/orderledger/main.go`: Example usage for developers

### API Usage
```go
client, _ := walmart.NewWalmartClient(config)
ledger, _ := client.GetOrderLedger("200013509224581")

// Access payment details
for _, pm := range ledger.PaymentMethods {
    fmt.Printf("%s ending in %s: $%.2f\n", 
        pm.CardType, pm.LastFour, pm.TotalCharged)
}
```

## Use Case
When syncing Walmart orders with bank transactions, the actual charge amounts are needed because Walmart often splits orders into multiple charges when items are edited or adjusted.

**Example**: Order total $185.83 might appear as:
- Visa charge 1: $178.96
- Visa charge 2: $4.12  
- Walmart Cash: $2.75

## Test Coverage
- ✅ All tests passing
- ✅ Helper function tests (parseAmount, extractLastFour)
- ✅ JSON unmarshaling tests
- ✅ Integration tests with mock server
- ✅ Edge cases (empty responses, malformed JSON, missing fields)