### PR TITLE
feat!: Add context.Context support for cancellation and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2025-12-24
+
+### Breaking Changes
+- **All public API methods now require `context.Context` as the first parameter**
+  - This enables proper cancellation, timeouts, and graceful shutdown
+  - Affected methods:
+    - `GetPurchaseHistory(ctx context.Context, req PurchaseHistoryRequest)`
+    - `GetRecentOrders(ctx context.Context, limit int)`
+    - `GetAllOrders(ctx context.Context, maxPages int)`
+    - `SearchOrders(ctx context.Context, searchTerm string, limit int)`
+    - `GetOrdersByType(ctx context.Context, orderType string, limit int)`
+    - `GetOrder(ctx context.Context, orderID string, isInStore bool)`
+    - `GetOrderAutoDetect(ctx context.Context, orderID string)`
+    - `GetDeliveryOrderWithTip(ctx context.Context, orderID string)`
+    - `GetOrdersAsJSON(ctx context.Context, limit int)`
+    - `GetOrderAsJSON(ctx context.Context, orderID string, isInStore bool)`
+    - `GetOrderLedger(ctx context.Context, orderID string)`
+
+### Added
+- **Context support for cancellation and timeouts** across all API methods
+  - Rate limiter waits are now cancellable via context
+  - HTTP requests use `http.NewRequestWithContext()` for proper cancellation
+  - Exponential backoff in `GetOrderLedger` retries is now cancellable
+- **Context cancellation test** (`TestGetOrderLedgerContextCancellation`)
+- Improved daemon mode with graceful shutdown via SIGINT/SIGTERM
+
+### Changed
+- Rate limiting now uses `select` with context for interruptible waits
+- `GetAllOrders` checks for context cancellation between page fetches
+- `GetOrderAutoDetect` checks for cancellation before retry attempt
+- Replaced `fmt.Printf` pagination logging in `GetAllOrders` with structured `logger.Debug`
+- CLI commands now use timeouts (2-10 minutes depending on operation)
+
+### Migration Guide
+To migrate from v1.x to v2.0.0, add `context.Context` as the first parameter to all API calls:
+
+```go
+// Before (v1.x)
+orders, err := client.GetRecentOrders(10)
+order, err := client.GetOrder(orderID, isInStore)
+ledger, err := client.GetOrderLedger(orderID)
+
+// After (v2.0.0)
+ctx := context.Background()
+orders, err := client.GetRecentOrders(ctx, 10)
+order, err := client.GetOrder(ctx, orderID, isInStore)
+ledger, err := client.GetOrderLedger(ctx, orderID)
+
+// With timeout
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+defer cancel()
+orders, err := client.GetRecentOrders(ctx, 10)
+```
+
 ## [1.0.9] - 2025-12-24
 
 ### Added
@@ -170,7 +224,8 @@ git push origin v1.0.3
 gh release create v1.0.3 --generate-notes
 ```
 
-[Unreleased]: https://github.com/eshaffer321/walmart-client-go/compare/v1.0.9...HEAD
+[Unreleased]: https://github.com/eshaffer321/walmart-client-go/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/eshaffer321/walmart-client-go/compare/v1.0.9...v2.0.0
 [1.0.9]: https://github.com/eshaffer321/walmart-client-go/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/eshaffer321/walmart-client-go/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/eshaffer321/walmart-client-go/compare/v1.0.6...v1.0.7

--- a/cmd/walmart/main.go
+++ b/cmd/walmart/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	walmart "github.com/eshaffer321/walmart-client-go"
@@ -71,7 +74,9 @@ func main() {
 	case *orderID != "":
 		// Fetch specific order
 		fmt.Printf("\n📦 Fetching order %s...\n", *orderID)
-		order, err := client.GetOrderAutoDetect(*orderID)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		order, err := client.GetOrderAutoDetect(ctx, *orderID)
 		if err != nil {
 			// Try to help user recover
 			fmt.Printf("\n❌ Failed: %v\n", err)
@@ -87,7 +92,9 @@ func main() {
 	case *history:
 		// Show recent purchase history
 		fmt.Println("\n📋 Fetching recent orders...")
-		orders, err := client.GetRecentOrders(10)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		orders, err := client.GetRecentOrders(ctx, 10)
 		if err != nil {
 			fmt.Printf("\n❌ Failed: %v\n", err)
 			os.Exit(1)
@@ -97,7 +104,9 @@ func main() {
 	case *search != "":
 		// Search orders
 		fmt.Printf("\n🔍 Searching for '%s' in orders...\n", *search)
-		orders, err := client.SearchOrders(*search, 20)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		orders, err := client.SearchOrders(ctx, *search, 20)
 		if err != nil {
 			fmt.Printf("\n❌ Failed: %v\n", err)
 			os.Exit(1)
@@ -107,7 +116,9 @@ func main() {
 	case *listAll:
 		// List all orders with pagination
 		fmt.Println("\n📋 Fetching all orders (max 5 pages)...")
-		orders, err := client.GetAllOrders(5)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		orders, err := client.GetAllOrders(ctx, 5)
 		if err != nil {
 			fmt.Printf("\n❌ Failed: %v\n", err)
 			os.Exit(1)
@@ -295,6 +306,13 @@ func runDaemon(client *walmart.WalmartClient) {
 	fmt.Println("   Will auto-refresh cookies every 30 minutes")
 	fmt.Println("   Press Ctrl+C to stop")
 
+	// Set up graceful shutdown
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
 	ticker := time.NewTicker(30 * time.Minute)
 	defer ticker.Stop()
 
@@ -303,11 +321,16 @@ func runDaemon(client *walmart.WalmartClient) {
 
 	for {
 		select {
+		case <-sigCh:
+			fmt.Println("\n👋 Shutting down daemon...")
+			return
 		case <-ticker.C:
 			fmt.Printf("\n[%s] Checking cookie health...\n", time.Now().Format("15:04:05"))
 
 			// Try to fetch an order as health check
-			_, err := client.GetOrder(testOrderID, true)
+			checkCtx, checkCancel := context.WithTimeout(ctx, 30*time.Second)
+			_, err := client.GetOrder(checkCtx, testOrderID, true)
+			checkCancel()
 			if err != nil {
 				fmt.Printf("⚠️  Cookies might be stale: %v\n", err)
 				fmt.Println("   Consider running: ./walmart -refresh")

--- a/doc.go
+++ b/doc.go
@@ -36,9 +36,12 @@
 //	    log.Fatal(err)
 //	}
 //
-// Fetch recent orders:
+// Fetch recent orders with context support for cancellation and timeouts:
 //
-//	orders, err := client.GetRecentOrders(10)
+//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+//	defer cancel()
+//
+//	orders, err := client.GetRecentOrders(ctx, 10)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -49,7 +52,7 @@
 //
 // Get detailed order information:
 //
-//	order, err := client.GetOrder(orderID, true)
+//	order, err := client.GetOrder(ctx, orderID, true)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -82,6 +85,26 @@
 //
 // A default 2-second delay is enforced between requests to prevent rate limiting
 // by Walmart's servers. This can be configured via ClientConfig.RateLimit.
+//
+// # Context Support
+//
+// All public API methods accept a context.Context as the first parameter,
+// enabling proper cancellation, timeouts, and graceful shutdown:
+//
+//   - Rate limiter waits are cancellable via context
+//   - HTTP requests respect context cancellation
+//   - Long-running operations like GetAllOrders check cancellation between pages
+//
+// Recommended timeouts:
+//   - Single order/history fetch: 1-2 minutes
+//   - Pagination operations (GetAllOrders): 5-10 minutes
+//   - Ledger requests: 2-5 minutes (has stricter rate limits)
+//
+// # Thread Safety
+//
+// WalmartClient is NOT safe for concurrent use from multiple goroutines.
+// The rate limiter state is not protected by a mutex. If you need concurrent
+// access, create separate client instances for each goroutine.
 //
 // # Order Types
 //

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -26,9 +27,13 @@ func main() {
 		panic(fmt.Sprintf("Failed to create client: %v", err))
 	}
 
+	// Create a context with timeout for all operations
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	// Example 1: Get recent orders
 	fmt.Println("\n=== Recent Orders ===")
-	orders, err := client.GetRecentOrders(5)
+	orders, err := client.GetRecentOrders(ctx, 5)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get recent orders: %v", err))
 	}
@@ -43,7 +48,7 @@ func main() {
 		orderID := orders[0].OrderID
 		isInStore := orders[0].FulfillmentType == "IN_STORE"
 
-		fullOrder, err := client.GetOrder(orderID, isInStore)
+		fullOrder, err := client.GetOrder(ctx, orderID, isInStore)
 		if err != nil {
 			panic(fmt.Sprintf("Failed to get order: %v", err))
 		}
@@ -59,7 +64,7 @@ func main() {
 
 	// Example 3: Search orders
 	fmt.Println("\n=== Search Results ===")
-	results, err := client.SearchOrders("bread", 10)
+	results, err := client.SearchOrders(ctx, "bread", 10)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to search orders: %v", err))
 	}

--- a/examples/ledger/main.go
+++ b/examples/ledger/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -26,11 +27,15 @@ func main() {
 		panic(fmt.Sprintf("Failed to create client: %v", err))
 	}
 
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	// Example order ID - replace with your actual order ID
 	orderID := "200013509224581"
 
 	// Get the order ledger showing actual credit card charges
-	ledger, err := client.GetOrderLedger(orderID)
+	ledger, err := client.GetOrderLedger(ctx, orderID)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get order ledger: %v", err))
 	}

--- a/ledger.go
+++ b/ledger.go
@@ -1,6 +1,7 @@
 package walmart
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -67,15 +68,21 @@ type RowLine struct {
 // GetOrderLedger fetches the payment ledger for an order showing actual charges.
 // This endpoint has stricter rate limits than other endpoints, so it uses a separate
 // rate limiter and implements retry logic with exponential backoff for 429 errors.
-func (c *WalmartClient) GetOrderLedger(orderID string) (*OrderLedger, error) {
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetOrderLedger(ctx context.Context, orderID string) (*OrderLedger, error) {
 	if orderID == "" {
 		return nil, fmt.Errorf("order ID is required")
 	}
 
-	// Use ledger-specific rate limiter (stricter than regular rate limit)
+	// Use ledger-specific rate limiter with context support
 	if !c.lastLedgerRequest.IsZero() {
 		c.logger.Debug("waiting for ledger rate limiter")
-		<-c.ledgerRateLimiter.C
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("request cancelled while rate limiting: %w", ctx.Err())
+		case <-c.ledgerRateLimiter.C:
+			// continue
+		}
 	}
 	c.lastLedgerRequest = time.Now()
 
@@ -101,6 +108,11 @@ func (c *WalmartClient) GetOrderLedger(orderID string) (*OrderLedger, error) {
 	}
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// Check for cancellation before each attempt
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("request cancelled: %w", err)
+		}
+
 		if attempt > 0 {
 			// Exponential backoff: 5s, 10s, 20s, 40s...
 			backoff := time.Duration(5*(1<<uint(attempt-1))) * time.Second
@@ -109,7 +121,16 @@ func (c *WalmartClient) GetOrderLedger(orderID string) (*OrderLedger, error) {
 				slog.Int("attempt", attempt),
 				slog.Int("max_retries", maxRetries),
 				slog.Duration("backoff", backoff))
-			time.Sleep(backoff)
+
+			// Use a timer for cancellable backoff
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, fmt.Errorf("request cancelled during backoff: %w", ctx.Err())
+			case <-timer.C:
+				// continue
+			}
 		}
 
 		c.logger.Debug("fetching order ledger",
@@ -117,7 +138,7 @@ func (c *WalmartClient) GetOrderLedger(orderID string) (*OrderLedger, error) {
 			slog.Int("attempt", attempt+1),
 			slog.Int("max_attempts", maxRetries+1))
 
-		req, err := http.NewRequest("GET", endpoint, nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 		if err != nil {
 			return nil, fmt.Errorf("creating request: %w", err)
 		}

--- a/orderledger_test.go
+++ b/orderledger_test.go
@@ -550,6 +550,49 @@ func TestGetOrderLedger403Response(t *testing.T) {
 	}
 }
 
+// TestGetOrderLedgerRateLimiterCancellation verifies rate limiter respects context cancellation
+func TestGetOrderLedgerRateLimiterCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data": {"getOrderLedger": {"paymentMethodsLedgers": []}}}`))
+	}))
+	defer server.Close()
+
+	// Create client with long rate limit (10 seconds between requests)
+	config := ClientConfig{
+		LedgerRateLimit: 10 * time.Second,
+		AutoSave:        false,
+	}
+	client, err := NewWalmartClient(config)
+	require.NoError(t, err)
+
+	client.httpClient = &http.Client{
+		Transport: &testTransport{
+			serverURL: server.URL,
+		},
+	}
+
+	// Make first request to set lastLedgerRequest
+	ctx := context.Background()
+	_, err = client.GetOrderLedger(ctx, "first-order")
+	require.NoError(t, err)
+
+	// Second request with short timeout - should fail during rate limit wait
+	ctx2, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	ledger, err := client.GetOrderLedger(ctx2, "second-order")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, ledger)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "rate limiting")
+	// Should have cancelled quickly, not waited 10 seconds
+	assert.Less(t, elapsed, 1*time.Second)
+}
+
 // TestGetOrderLedgerContextCancellation verifies context cancellation works
 func TestGetOrderLedgerContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -580,8 +623,8 @@ func TestGetOrderLedgerContextCancellation(t *testing.T) {
 	ledger, err := client.GetOrderLedger(ctx, "test-order")
 	require.Error(t, err)
 	assert.Nil(t, ledger)
-	// Should contain context deadline or cancellation error
-	assert.True(t, err != nil)
+	// Should contain context deadline exceeded error
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestParseAmount(t *testing.T) {

--- a/orderledger_test.go
+++ b/orderledger_test.go
@@ -1,6 +1,7 @@
 package walmart
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -414,7 +415,8 @@ func TestGetOrderLedger(t *testing.T) {
 				},
 			}
 
-			ledger, err := client.GetOrderLedger(tt.orderID)
+			ctx := context.Background()
+			ledger, err := client.GetOrderLedger(ctx, tt.orderID)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -459,8 +461,9 @@ func TestGetOrderLedgerRateLimiting(t *testing.T) {
 	}
 
 	// Make 3 ledger requests
+	ctx := context.Background()
 	for i := 0; i < 3; i++ {
-		_, err := client.GetOrderLedger("test-order")
+		_, err := client.GetOrderLedger(ctx, "test-order")
 		require.NoError(t, err)
 	}
 
@@ -499,7 +502,8 @@ func TestGetOrderLedger429Response(t *testing.T) {
 		},
 	}
 
-	ledger, err := client.GetOrderLedger("test-order")
+	ctx := context.Background()
+	ledger, err := client.GetOrderLedger(ctx, "test-order")
 	require.Error(t, err)
 	assert.Nil(t, ledger)
 	assert.Contains(t, err.Error(), "rate limited")
@@ -536,13 +540,48 @@ func TestGetOrderLedger403Response(t *testing.T) {
 				},
 			}
 
-			ledger, err := client.GetOrderLedger("test-order")
+			ctx := context.Background()
+			ledger, err := client.GetOrderLedger(ctx, "test-order")
 			require.Error(t, err)
 			assert.Nil(t, ledger)
 			assert.Contains(t, err.Error(), "access denied")
 			assert.Contains(t, err.Error(), "cookies might be stale")
 		})
 	}
+}
+
+// TestGetOrderLedgerContextCancellation verifies context cancellation works
+func TestGetOrderLedgerContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate slow response
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data": {"getOrderLedger": {"paymentMethodsLedgers": []}}}`))
+	}))
+	defer server.Close()
+
+	config := ClientConfig{
+		RateLimit: time.Millisecond * 10,
+		AutoSave:  false,
+	}
+	client, err := NewWalmartClient(config)
+	require.NoError(t, err)
+
+	client.httpClient = &http.Client{
+		Transport: &testTransport{
+			serverURL: server.URL,
+		},
+	}
+
+	// Create a context that we cancel immediately
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	ledger, err := client.GetOrderLedger(ctx, "test-order")
+	require.Error(t, err)
+	assert.Nil(t, ledger)
+	// Should contain context deadline or cancellation error
+	assert.True(t, err != nil)
 }
 
 func TestParseAmount(t *testing.T) {

--- a/orders.go
+++ b/orders.go
@@ -1,6 +1,7 @@
 package walmart
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,12 +14,18 @@ import (
 	"github.com/eshaffer321/walmart-client-go/internal/cookies"
 )
 
-// GetOrder fetches an order with automatic cookie updates
-func (c *WalmartClient) GetOrder(orderID string, isInStore bool) (*Order, error) {
-	// Rate limiting - only wait if not first request
+// GetOrder fetches an order with automatic cookie updates.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetOrder(ctx context.Context, orderID string, isInStore bool) (*Order, error) {
+	// Rate limiting with context support
 	if !c.lastRequest.IsZero() {
 		c.logger.Debug("waiting for rate limiter")
-		<-c.rateLimiter.C
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("request cancelled while rate limiting: %w", ctx.Err())
+		case <-c.rateLimiter.C:
+			// continue
+		}
 	}
 	c.lastRequest = time.Now()
 
@@ -29,7 +36,7 @@ func (c *WalmartClient) GetOrder(orderID string, isInStore bool) (*Order, error)
 		slog.Bool("is_in_store", isInStore),
 		slog.String("endpoint", endpoint))
 
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		c.logger.Error("failed to create request",
 			slog.String("order_id", orderID),
@@ -132,16 +139,22 @@ func (c *WalmartClient) GetOrder(orderID string, isInStore bool) (*Order, error)
 	return order, nil
 }
 
-// GetOrderAutoDetect tries to fetch an order, automatically detecting if it's in-store or delivery
-func (c *WalmartClient) GetOrderAutoDetect(orderID string) (*Order, error) {
+// GetOrderAutoDetect tries to fetch an order, automatically detecting if it's in-store or delivery.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetOrderAutoDetect(ctx context.Context, orderID string) (*Order, error) {
 	// First try as in-store (most common for the user's examples)
-	order, err := c.GetOrder(orderID, true)
+	order, err := c.GetOrder(ctx, orderID, true)
 	if err == nil {
 		return order, nil
 	}
 
+	// Check for cancellation before retrying
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("request cancelled: %w", ctx.Err())
+	}
+
 	// If that fails, try as delivery order
-	order, err = c.GetOrder(orderID, false)
+	order, err = c.GetOrder(ctx, orderID, false)
 	if err == nil {
 		return order, nil
 	}
@@ -149,10 +162,11 @@ func (c *WalmartClient) GetOrderAutoDetect(orderID string) (*Order, error) {
 	return nil, fmt.Errorf("order not found as either in-store or delivery: %w", err)
 }
 
-// GetDeliveryOrderWithTip fetches a delivery order and ensures tip information is included
-func (c *WalmartClient) GetDeliveryOrderWithTip(orderID string) (*Order, error) {
+// GetDeliveryOrderWithTip fetches a delivery order and ensures tip information is included.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetDeliveryOrderWithTip(ctx context.Context, orderID string) (*Order, error) {
 	// Fetch as delivery order (isInStore = false)
-	order, err := c.GetOrder(orderID, false)
+	order, err := c.GetOrder(ctx, orderID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -165,9 +179,10 @@ func (c *WalmartClient) GetDeliveryOrderWithTip(orderID string) (*Order, error) 
 	return order, nil
 }
 
-// GetOrdersAsJSON is a helper that returns recent orders as JSON string
-func (c *WalmartClient) GetOrdersAsJSON(limit int) (string, error) {
-	orders, err := c.GetRecentOrders(limit)
+// GetOrdersAsJSON is a helper that returns recent orders as JSON string.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetOrdersAsJSON(ctx context.Context, limit int) (string, error) {
+	orders, err := c.GetRecentOrders(ctx, limit)
 	if err != nil {
 		return "", err
 	}
@@ -180,9 +195,10 @@ func (c *WalmartClient) GetOrdersAsJSON(limit int) (string, error) {
 	return string(jsonData), nil
 }
 
-// GetOrderAsJSON is a helper that returns order details as JSON string
-func (c *WalmartClient) GetOrderAsJSON(orderID string, isInStore bool) (string, error) {
-	order, err := c.GetOrder(orderID, isInStore)
+// GetOrderAsJSON is a helper that returns order details as JSON string.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetOrderAsJSON(ctx context.Context, orderID string, isInStore bool) (string, error) {
+	order, err := c.GetOrder(ctx, orderID, isInStore)
 	if err != nil {
 		return "", err
 	}

--- a/purchases.go
+++ b/purchases.go
@@ -1,6 +1,7 @@
 package walmart
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -80,12 +81,18 @@ type ItemSummary struct {
 	} `json:"imageInfo"`
 }
 
-// GetPurchaseHistory fetches the purchase history with optional filters
-func (c *WalmartClient) GetPurchaseHistory(req PurchaseHistoryRequest) (*PurchaseHistoryResponse, error) {
-	// Rate limiting
+// GetPurchaseHistory fetches the purchase history with optional filters.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetPurchaseHistory(ctx context.Context, req PurchaseHistoryRequest) (*PurchaseHistoryResponse, error) {
+	// Rate limiting with context support
 	if !c.lastRequest.IsZero() {
 		c.logger.Debug("waiting for rate limiter")
-		<-c.rateLimiter.C
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("request cancelled while rate limiting: %w", ctx.Err())
+		case <-c.rateLimiter.C:
+			// continue
+		}
 	}
 	c.lastRequest = time.Now()
 
@@ -112,7 +119,7 @@ func (c *WalmartClient) GetPurchaseHistory(req PurchaseHistoryRequest) (*Purchas
 	c.logger.Debug("purchase history request",
 		slog.String("endpoint", endpoint))
 
-	httpReq, err := http.NewRequest("GET", endpoint, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		c.logger.Error("failed to create request",
 			slog.String("error", err.Error()))
@@ -185,13 +192,14 @@ func (c *WalmartClient) GetPurchaseHistory(req PurchaseHistoryRequest) (*Purchas
 	return &historyResp, nil
 }
 
-// GetRecentOrders is a convenience method to get recent orders
-func (c *WalmartClient) GetRecentOrders(limit int) ([]OrderSummary, error) {
+// GetRecentOrders is a convenience method to get recent orders.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetRecentOrders(ctx context.Context, limit int) ([]OrderSummary, error) {
 	req := PurchaseHistoryRequest{
 		Limit: limit,
 	}
 
-	resp, err := c.GetPurchaseHistory(req)
+	resp, err := c.GetPurchaseHistory(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -199,18 +207,24 @@ func (c *WalmartClient) GetRecentOrders(limit int) ([]OrderSummary, error) {
 	return resp.Data.OrderHistoryV2.OrderGroups, nil
 }
 
-// GetAllOrders fetches all orders with pagination
-func (c *WalmartClient) GetAllOrders(maxPages int) ([]OrderSummary, error) {
+// GetAllOrders fetches all orders with pagination.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetAllOrders(ctx context.Context, maxPages int) ([]OrderSummary, error) {
 	var allOrders []OrderSummary
 	cursor := ""
 
 	for page := 0; page < maxPages; page++ {
+		// Check for cancellation before each page
+		if err := ctx.Err(); err != nil {
+			return allOrders, fmt.Errorf("cancelled after %d pages: %w", page, err)
+		}
+
 		req := PurchaseHistoryRequest{
 			Cursor: cursor,
 			Limit:  20,
 		}
 
-		resp, err := c.GetPurchaseHistory(req)
+		resp, err := c.GetPurchaseHistory(ctx, req)
 		if err != nil {
 			return allOrders, fmt.Errorf("failed on page %d: %w", page+1, err)
 		}
@@ -223,21 +237,24 @@ func (c *WalmartClient) GetAllOrders(maxPages int) ([]OrderSummary, error) {
 			break
 		}
 
-		fmt.Printf("Fetched page %d, got %d orders (total: %d)\n",
-			page+1, len(resp.Data.OrderHistoryV2.OrderGroups), len(allOrders))
+		c.logger.Debug("fetched page",
+			slog.Int("page", page+1),
+			slog.Int("page_orders", len(resp.Data.OrderHistoryV2.OrderGroups)),
+			slog.Int("total_orders", len(allOrders)))
 	}
 
 	return allOrders, nil
 }
 
-// SearchOrders searches for orders containing a specific item
-func (c *WalmartClient) SearchOrders(searchTerm string, limit int) ([]OrderSummary, error) {
+// SearchOrders searches for orders containing a specific item.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) SearchOrders(ctx context.Context, searchTerm string, limit int) ([]OrderSummary, error) {
 	req := PurchaseHistoryRequest{
 		Search: searchTerm,
 		Limit:  limit,
 	}
 
-	resp, err := c.GetPurchaseHistory(req)
+	resp, err := c.GetPurchaseHistory(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -245,14 +262,15 @@ func (c *WalmartClient) SearchOrders(searchTerm string, limit int) ([]OrderSumma
 	return resp.Data.OrderHistoryV2.OrderGroups, nil
 }
 
-// GetOrdersByType fetches orders of a specific type
-func (c *WalmartClient) GetOrdersByType(orderType string, limit int) ([]OrderSummary, error) {
+// GetOrdersByType fetches orders of a specific type.
+// The context can be used to cancel the request or set a deadline.
+func (c *WalmartClient) GetOrdersByType(ctx context.Context, orderType string, limit int) ([]OrderSummary, error) {
 	req := PurchaseHistoryRequest{
 		Type:  &orderType,
 		Limit: limit,
 	}
 
-	resp, err := c.GetPurchaseHistory(req)
+	resp, err := c.GetPurchaseHistory(ctx, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Adds `context.Context` as the first parameter to all public API methods
- Enables proper cancellation, timeouts, and graceful shutdown for calling applications

## Breaking Change
This is a **v2.0.0 release** with breaking API changes. All public methods now require `context.Context` as the first parameter.

## Motivation
From the feature request: When users cancel a sync job or when the application needs to shut down, HTTP requests to Walmart's API cannot be cancelled - they continue running until they either complete or hit the 30-second HTTP client timeout. A sync job with 10 orders can take up to 6+ minutes to cancel.

## Changes
- **Rate limiting**: Now uses `select` with `ctx.Done()` for interruptible waits
- **HTTP requests**: Use `http.NewRequestWithContext()` for proper cancellation
- **GetOrderLedger**: Exponential backoff retries are now cancellable
- **GetAllOrders**: Checks cancellation between page fetches
- **CLI**: Commands use appropriate timeouts, daemon mode supports graceful shutdown

## Affected Methods
| Method | New Signature |
|--------|--------------|
| GetPurchaseHistory | `(ctx context.Context, req PurchaseHistoryRequest)` |
| GetRecentOrders | `(ctx context.Context, limit int)` |
| GetAllOrders | `(ctx context.Context, maxPages int)` |
| SearchOrders | `(ctx context.Context, searchTerm string, limit int)` |
| GetOrdersByType | `(ctx context.Context, orderType string, limit int)` |
| GetOrder | `(ctx context.Context, orderID string, isInStore bool)` |
| GetOrderAutoDetect | `(ctx context.Context, orderID string)` |
| GetDeliveryOrderWithTip | `(ctx context.Context, orderID string)` |
| GetOrdersAsJSON | `(ctx context.Context, limit int)` |
| GetOrderAsJSON | `(ctx context.Context, orderID string, isInStore bool)` |
| GetOrderLedger | `(ctx context.Context, orderID string)` |

## Migration Example
```go
// Before (v1.x)
orders, err := client.GetRecentOrders(10)

// After (v2.0.0)
ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
defer cancel()
orders, err := client.GetRecentOrders(ctx, 10)
```

## Test plan
- [x] All existing tests pass with context.Background()
- [x] New `TestGetOrderLedgerContextCancellation` test verifies cancellation works
- [x] Build succeeds for all packages including CLI and examples
- [ ] CI pipeline passes