### PR TITLE
feat: expose returned Walmart order items

### DIFF
--- a/models.go
+++ b/models.go
@@ -58,6 +58,38 @@ func (o *Order) GetItems() []OrderItem {
 	return items
 }
 
+// GetRefundedItems returns order items that Walmart marked with a return ID.
+// Walmart renders category and subgroup views of the same item, so results are
+// deduplicated by return ID and Walmart item ID.
+func (o *Order) GetRefundedItems() []OrderItem {
+	seen := make(map[string]bool)
+	var refunded []OrderItem
+	appendItems := func(items []OrderItem) {
+		for _, item := range items {
+			if item.ReturnID == "" {
+				continue
+			}
+			key := item.ReturnID + ":" + item.ID
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			refunded = append(refunded, item)
+		}
+	}
+	for _, group := range o.Groups {
+		for _, category := range group.Categories {
+			appendItems(category.Items)
+		}
+		for _, subgroup := range group.SubGroups {
+			for _, category := range subgroup.Categories {
+				appendItems(category.Items)
+			}
+		}
+	}
+	return refunded
+}
+
 // Customer information.
 type Customer struct {
 	ID                string  `json:"id"`
@@ -79,6 +111,18 @@ type OrderGroup struct {
 	Store           *Store          `json:"store"`
 	PriceDetails    *PriceDetails   `json:"priceDetails"`
 	PaymentDetails  *PaymentDetails `json:"paymentDetails"`
+	Categories      []OrderCategory `json:"categories"`
+	SubGroups       []OrderSubGroup `json:"subGroups"`
+}
+
+// OrderCategory is a Walmart UI grouping of fulfilled order items.
+type OrderCategory struct {
+	Items []OrderItem `json:"items"`
+}
+
+// OrderSubGroup contains nested category views for an order group.
+type OrderSubGroup struct {
+	Categories []OrderCategory `json:"categories"`
 }
 
 // Store represents store information.
@@ -144,6 +188,7 @@ type MessagePart struct {
 // OrderItem represents an individual item in an order.
 type OrderItem struct {
 	ID          string       `json:"id"`
+	ReturnID    string       `json:"returnId"`
 	Quantity    float64      `json:"quantity"`
 	ProductInfo *ProductInfo `json:"productInfo"`
 	PriceInfo   *ItemPrice   `json:"priceInfo"`

--- a/orders_test.go
+++ b/orders_test.go
@@ -72,6 +72,27 @@ func TestGetOrderSuccess(t *testing.T) {
 	assert.Equal(t, 10.0, order.PriceDetails.GrandTotal.Value)
 }
 
+func TestOrder_GetRefundedItems_DeduplicatesCategoryAndSubgroupViews(t *testing.T) {
+	const response = `{
+  "data": {"order": {"id": "refund-1", "groups_2101": [{
+    "categories": [{"items": [{"id": "i1", "returnId": "return-1", "quantity": 1, "productInfo": {"name": "Refunded creamer", "usItemId": "sku-1"}, "priceInfo": {"linePrice": {"value": 5.26}}}]}],
+    "subGroups": [{"categories": [{"items": [{"id": "i1", "returnId": "return-1", "quantity": 1, "productInfo": {"name": "Refunded creamer", "usItemId": "sku-1"}, "priceInfo": {"linePrice": {"value": 5.26}}}]}]}]
+  }]}}
+}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(response))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	order, err := newMockClient(t, server.URL).GetOrder(context.Background(), "refund-1", false)
+	require.NoError(t, err)
+	items := order.GetRefundedItems()
+	require.Len(t, items, 1)
+	assert.Equal(t, "return-1", items[0].ReturnID)
+	assert.Equal(t, "Refunded creamer", items[0].ProductInfo.Name)
+}
+
 func TestGetOrderDeliveryCalculatesTotalWithTip(t *testing.T) {
 	const deliveryJSON = `{
 		"data": {


### PR DESCRIPTION
## Description
Expose the item-level `returnId` metadata already present in Walmart order responses.

`Order.GetRefundedItems()` returns typed refunded items from category and subgroup views, deduplicated by Walmart return and item IDs.

## Testing
- `go test ./... -race`
- Added regression coverage for duplicate category/subgroup UI representations.

## Review
The change is backwards compatible: it only adds fields and a new accessor; `GetOrder` continues to make the same single request.