### PR TITLE
fix: harden Walmart browser sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-15
+
+### Added
+- `GetOrderWithGroup` sends the purchase-history group ID with order-detail requests.
+- `ErrBotChallenge` lets callers detect Walmart's HTTP 456 bot-protection response with `errors.Is`.
+
+### Changed
+- Browser cURL imports now capture the active `getOrder` persisted-query hash and a safe request-header profile alongside cookies.
+- Refreshing from cURL replaces the previous browser snapshot instead of retaining stale WAF cookies.
+- Order, purchase-history, and ledger requests now use current browser headers plus per-request correlation and trace IDs.
+
+### Fixed
+- Updated the `getOrder` GraphQL variables and persisted-query hash to match Walmart's current web client.
+- `GetOrderAutoDetect` no longer repeats a request after an HTTP 456 bot challenge.
+- Cookie files are saved atomically with owner-only permissions, including files created by older releases.
+
 ## [2.1.0] - 2026-07-10
 
 ### Added
@@ -246,7 +262,8 @@ git push origin v1.0.3
 gh release create v1.0.3 --generate-notes
 ```
 
-[Unreleased]: https://github.com/eshaffer321/walmart-client-go/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/eshaffer321/walmart-client-go/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/eshaffer321/walmart-client-go/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/eshaffer321/walmart-client-go/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/eshaffer321/walmart-client-go/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/eshaffer321/walmart-client-go/compare/v2.0.0...v2.0.1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd walmart-client-go
 go build -o walmart-cli ./cmd/walmart
 
 # Or install directly
-go install github.com/eshaffer321/walmart-client/cmd/walmart@latest
+go install github.com/eshaffer321/walmart-client-go/v2/cmd/walmart@latest
 ```
 
 ## Library Usage (Go SDK)
@@ -46,11 +46,12 @@ go install github.com/eshaffer321/walmart-client/cmd/walmart@latest
 package main
 
 import (
+	"context"
     "encoding/json"
     "fmt"
     "time"
     
-    walmart "github.com/eshaffer321/walmart-client"
+    walmart "github.com/eshaffer321/walmart-client-go/v2"
 )
 
 func main() {
@@ -71,8 +72,10 @@ func main() {
         panic(err)
     }
     
+    ctx := context.Background()
+
     // Get recent orders as Go structs
-    orders, err := client.GetRecentOrders(10)
+    orders, err := client.GetRecentOrders(ctx, 10)
     if err != nil {
         panic(err)
     }
@@ -84,7 +87,9 @@ func main() {
     
     // Get full order details
     if len(orders) > 0 {
-        order, err := client.GetOrder(orders[0].OrderID, true)
+        order, err := client.GetOrderWithGroup(
+            ctx, orders[0].OrderID, orders[0].GroupID, true,
+        )
         if err != nil {
             panic(err)
         }
@@ -160,16 +165,17 @@ All logs automatically include `client=walmart` attribute for filtering in multi
 ### Available Methods
 ```go
 // Order operations
-client.GetOrder(orderID string, isInStore bool) (*Order, error)
-client.GetOrderAutoDetect(orderID string) (*Order, error)
-client.GetDeliveryOrderWithTip(orderID string) (*Order, error) // Ensures tip info is included
-client.GetOrderLedger(orderID string) (*OrderLedger, error)    // NEW: Get payment ledger for bank reconciliation
+client.GetOrder(ctx context.Context, orderID string, isInStore bool) (*Order, error)
+client.GetOrderWithGroup(ctx context.Context, orderID, groupID string, isInStore bool) (*Order, error)
+client.GetOrderAutoDetect(ctx context.Context, orderID string) (*Order, error)
+client.GetDeliveryOrderWithTip(ctx context.Context, orderID string) (*Order, error)
+client.GetOrderLedger(ctx context.Context, orderID string) (*OrderLedger, error)
 
 // Purchase history
-client.GetRecentOrders(limit int) ([]OrderSummary, error)
-client.GetAllOrders(maxPages int) ([]OrderSummary, error)
-client.SearchOrders(searchTerm string, limit int) ([]OrderSummary, error)
-client.GetOrdersByType(orderType string, limit int) ([]OrderSummary, error)
+client.GetRecentOrders(ctx context.Context, limit int) ([]OrderSummary, error)
+client.GetAllOrders(ctx context.Context, maxPages int) ([]OrderSummary, error)
+client.SearchOrders(ctx context.Context, searchTerm string, limit int) ([]OrderSummary, error)
+client.GetOrdersByType(ctx context.Context, orderType string, limit int) ([]OrderSummary, error)
 
 // Cookie management
 client.InitializeFromCurl(curlFile string) error
@@ -177,8 +183,8 @@ client.Status() // Print status
 client.RefreshFromBrowser() error
 
 // Helper methods for JSON output
-client.GetOrdersAsJSON(limit int) (string, error)
-client.GetOrderAsJSON(orderID string, isInStore bool) (string, error)
+client.GetOrdersAsJSON(ctx context.Context, limit int) (string, error)
+client.GetOrderAsJSON(ctx context.Context, orderID string, isInStore bool) (string, error)
 ```
 
 ### Data Structures
@@ -247,7 +253,7 @@ The order ledger API provides detailed payment information showing actual credit
 
 ```go
 // Get payment ledger for an order
-ledger, err := client.GetOrderLedger("200013509224581")
+ledger, err := client.GetOrderLedger(ctx, "200013509224581")
 if err != nil {
     log.Fatal(err)
 }
@@ -299,7 +305,7 @@ The order ledger provides these actual charge amounts, making it possible to acc
 ./walmart-cli -init curl.txt
 ```
 
-This saves your cookies to `~/.walmart-api/cookies.json` for future use.
+This saves the current browser cookie snapshot, `getOrder` query hash, and safe request profile to `~/.walmart-api/cookies.json`. The cURL file contains session credentials; keep it private and delete it when initialization succeeds.
 
 ### CLI Commands
 
@@ -360,7 +366,7 @@ This saves your cookies to `~/.walmart-api/cookies.json` for future use.
 
 # Output:
 # === Cookie Store Status ===
-# Total cookies: 61
+# Total cookies: 62
 # Cookie file: /Users/you/.walmart-api/cookies.json
 # Essential cookies: 6
 # 
@@ -380,10 +386,10 @@ This saves your cookies to `~/.walmart-api/cookies.json` for future use.
 ## How It Works
 
 ### Authentication
-- Uses 61 cookies from your browser session
-- **CID** and **SPID** are the essential auth cookies
-- However, ALL 61 cookies are required to avoid bot detection (429/418 errors)
-- 19 cookies automatically update with each request to prevent staleness
+- Replays the complete cookie snapshot from your current browser session
+- Captures the live `getOrder` hash and browser request profile instead of hard-coding a stale fingerprint
+- Replaces old cookies on refresh so expired WAF state cannot leak into the new session
+- Automatically incorporates cookie updates returned by Walmart
 
 ### API Endpoints
 
@@ -441,7 +447,14 @@ Cookies are stored in `~/.walmart-api/cookies.json` with metadata:
     },
     ...
   },
-  "last_update": "2025-09-07T08:40:57Z"
+  "last_update": "2025-09-07T08:40:57Z",
+  "request_profile": {
+    "get_order_hash": "...",
+    "headers": {
+      "user-agent": "...",
+      "x-o-platform-version": "..."
+    }
+  }
 }
 ```
 
@@ -450,7 +463,7 @@ Cookies are stored in `~/.walmart-api/cookies.json` with metadata:
 ### Rate Limiting
 - Built-in 2-second delay between requests
 - Automatic cookie updates to prevent staleness
-- Proper error handling for rate limits (429) and bot detection (418)
+- Proper error handling for rate limits (429) and bot detection (418/456)
 
 ### GraphQL Persisted Queries
 Walmart uses persisted queries where the query is stored server-side and referenced by hash:
@@ -468,7 +481,7 @@ Walmart uses persisted queries where the query is stored server-side and referen
 - This is for personal use only - be respectful of Walmart's servers
 - Cookies expire after some time - refresh from browser when needed
 - Rate limiting is enforced to avoid detection
-- All 61 cookies are required despite only 2 containing auth data
+- Refresh from a newly copied `getOrder` cURL request when `ErrBotChallenge` is returned
 
 ## License
 

--- a/client.go
+++ b/client.go
@@ -8,12 +8,15 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/eshaffer321/walmart-client-go/v2/internal/cookies"
 )
+
+var getOrderHashPattern = regexp.MustCompile(`/orchestra/orders/graphql/getOrder/([a-f0-9]{64})([/?]|$)`)
 
 // WalmartClient provides access to Walmart's order history and purchase data API.
 type WalmartClient struct {
@@ -103,23 +106,31 @@ func NewWalmartClient(config ClientConfig) (*WalmartClient, error) {
 func (c *WalmartClient) InitializeFromCurl(curlFile string) error {
 	// The curl file path is supplied by the caller of this library, not by
 	// untrusted input, so reading it directly is intended behavior.
-	data, err := os.ReadFile(curlFile) //nolint:gosec // G304: caller-controlled path
+	// #nosec G304 -- caller-controlled configuration is the public API contract.
+	data, err := os.ReadFile(curlFile)
 	if err != nil {
 		return fmt.Errorf("failed to read curl file: %w", err)
 	}
 
-	parsedCookies := cookies.ExtractFromCurl(string(data))
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	capture := cookies.ParseCurl(string(data))
+	if len(capture.Cookies) == 0 {
+		return fmt.Errorf("curl capture contains no cookies")
+	}
+	for _, name := range []string{cookieNameCID, cookieNameSPID, cookieNameAuth} {
+		if capture.Cookies[name] == "" {
+			return fmt.Errorf("curl capture is missing required %s cookie", name)
+		}
+	}
 
 	// Mark essential cookies.
 	essentialCookies := cookies.Essential()
+	replacement := make(map[string]*cookies.Cookie, len(capture.Cookies))
+	now := time.Now()
 
-	for name, value := range parsedCookies {
+	for name, value := range capture.Cookies {
 		cookie := &cookies.Cookie{
 			Value:      value,
-			LastUpdate: time.Now(),
+			LastUpdate: now,
 			Source:     "curl",
 			Essential:  false,
 		}
@@ -132,8 +143,22 @@ func (c *WalmartClient) InitializeFromCurl(curlFile string) error {
 			}
 		}
 
-		c.cookieStore.Set(name, cookie)
+		replacement[name] = cookie
 	}
+
+	profile := cookies.RequestProfile{Headers: make(map[string]string)}
+	if match := getOrderHashPattern.FindStringSubmatch(capture.URL); len(match) >= 2 {
+		profile.GetOrderHash = match[1]
+	}
+	for name, value := range capture.Headers {
+		if _, ok := requestProfileHeaderAllowlist[name]; ok {
+			profile.Headers[name] = value
+		}
+	}
+
+	// A browser refresh is a coherent session snapshot. Replace instead of
+	// merging so expired WAF cookies from an older capture cannot survive.
+	c.cookieStore.Replace(replacement, profile)
 
 	// Auto-save.
 	if err := c.cookieStore.Save(); err != nil {
@@ -188,7 +213,7 @@ func (c *WalmartClient) Status() {
 
 	// Show essential cookies status.
 	fmt.Println("\nEssential cookies:")
-	essentials := []string{"CID", "SPID", "auth", "customer"}
+	essentials := []string{cookieNameCID, cookieNameSPID, cookieNameAuth, "customer"}
 	missingEssential := []string{}
 	for _, name := range essentials {
 		if cookie := c.cookieStore.Get(name); cookie != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -215,9 +216,43 @@ func TestBuildOrderEndpoint(t *testing.T) {
 		t.Error("Endpoint doesn't contain order ID")
 	}
 
-	// Check it has the GraphQL hash.
-	if !contains(endpoint, "d0622497daef19150438d07c506739d451cad6749cf45c3b4db95f2f5a0a65c4") {
-		t.Error("Endpoint doesn't contain correct GraphQL hash")
+	// Check it has the current GraphQL hash captured from Walmart's web app.
+	if !contains(endpoint, "0d0e73dcfbe4c7a4cb6c8ce929e5b9a8b3e731e4bac81969eed76dbdab28b0d2") {
+		t.Error("Endpoint doesn't contain current GraphQL hash")
+	}
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatalf("Failed to parse endpoint: %v", err)
+	}
+	var variables map[string]any
+	if err := json.Unmarshal([]byte(parsed.Query().Get("variables")), &variables); err != nil {
+		t.Fatalf("Failed to parse variables: %v", err)
+	}
+
+	wantKeys := []string{
+		"clickThroughGroupId",
+		"eligibleFeatures",
+		"enableCancelFix",
+		"enableGroupBannerMessages",
+		"enableIsWcpOrder",
+		"enableSignOnDelivery",
+		"enableVolumePricing",
+		"enableWcpPhaseOrder",
+		"enabledFeatures",
+		graphqlOrderIDVariable,
+		"orderIsInStore",
+	}
+	for _, key := range wantKeys {
+		if _, ok := variables[key]; !ok {
+			t.Errorf("Endpoint variables missing %q", key)
+		}
+	}
+	if _, ok := variables["includeTipDetails"]; ok {
+		t.Error("Endpoint still sends obsolete includeTipDetails variable")
+	}
+	if _, ok := variables["includeFeesDetails"]; ok {
+		t.Error("Endpoint still sends obsolete includeFeesDetails variable")
 	}
 }
 
@@ -260,8 +295,8 @@ func TestMockOrderRequest(t *testing.T) {
 	// so we'll just test that the request would be made correctly.
 
 	// Add required cookies.
-	client.cookieStore.Set("CID", &cookies.Cookie{Value: "test"})
-	client.cookieStore.Set("SPID", &cookies.Cookie{Value: "test"})
+	client.cookieStore.Set(cookieNameCID, &cookies.Cookie{Value: testSource})
+	client.cookieStore.Set(cookieNameSPID, &cookies.Cookie{Value: testSource})
 
 	// Since we can't override the endpoint builder, just verify the endpoint is built correctly.
 	endpoint := client.buildOrderEndpoint("TEST123", true)
@@ -306,7 +341,7 @@ func TestInitializeFromCurl(t *testing.T) {
 	}
 
 	// Check essential cookies were loaded.
-	cid := client.cookieStore.Get("CID")
+	cid := client.cookieStore.Get(cookieNameCID)
 	if cid == nil || cid.Value != "test_cid" {
 		t.Error("CID cookie not loaded correctly")
 	}
@@ -314,12 +349,52 @@ func TestInitializeFromCurl(t *testing.T) {
 		t.Error("CID should be marked as essential")
 	}
 
-	spid := client.cookieStore.Get("SPID")
+	spid := client.cookieStore.Get(cookieNameSPID)
 	if spid == nil || spid.Value != "test_spid" {
 		t.Error("SPID cookie not loaded correctly")
 	}
 	if !spid.Essential {
 		t.Error("SPID should be marked as essential")
+	}
+}
+
+func TestInitializeFromCurlReplacesStaleCookies(t *testing.T) {
+	tempDir := t.TempDir()
+	client, err := NewWalmartClient(ClientConfig{CookieDir: tempDir})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.cookieStore.Set("stale-waf-cookie", &cookies.Cookie{Value: "old"})
+
+	curlContent := `curl 'https://www.walmart.com/orchestra/orders/graphql/getOrder/0d0e73dcfbe4c7a4cb6c8ce929e5b9a8b3e731e4bac81969eed76dbdab28b0d2?variables=%7B%7D' \
+  -H 'user-agent: Mozilla/5.0 Chrome/149.0.0.0' \
+  -H 'x-o-platform-version: usweb-1.284.0-test' \
+  -b 'CID=test_cid; SPID=test_spid; auth=test_auth'`
+	curlFile := filepath.Join(tempDir, "fresh.curl")
+	if err := os.WriteFile(curlFile, []byte(curlContent), 0600); err != nil {
+		t.Fatalf("Failed to write curl fixture: %v", err)
+	}
+
+	if err := client.InitializeFromCurl(curlFile); err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	if got := client.cookieStore.Get("stale-waf-cookie"); got != nil {
+		t.Error("InitializeFromCurl retained a stale cookie from the previous browser capture")
+	}
+	if got := client.cookieStore.Count(); got != 3 {
+		t.Errorf("Expected exactly 3 cookies from fresh capture, got %d", got)
+	}
+
+	profile := client.cookieStore.GetRequestProfile()
+	if profile.GetOrderHash != "0d0e73dcfbe4c7a4cb6c8ce929e5b9a8b3e731e4bac81969eed76dbdab28b0d2" {
+		t.Errorf("Unexpected captured getOrder hash %q", profile.GetOrderHash)
+	}
+	if got := profile.Headers[headerUserAgent]; got != testCapturedUserAgent {
+		t.Errorf("Unexpected captured user agent %q", got)
+	}
+	if got := profile.Headers[headerPlatformVersion]; got != testCapturedPlatform {
+		t.Errorf("Unexpected captured Walmart platform version %q", got)
 	}
 }
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -44,9 +44,11 @@ order := walmart.Order{}
 ### Key Design Patterns
 
 #### 1. Cookie Management
-Walmart requires ALL 61 cookies from browser session to avoid bot detection. The cookie store:
+Walmart requires a coherent cookie snapshot and request profile from the same browser session. The cookie store:
 - Persists to `~/.walmart-api/cookies.json`
-- Auto-updates 19 cookies from each response
+- Replaces the previous snapshot when importing a fresh `getOrder` cURL request
+- Persists the active GraphQL hash and allowlisted browser headers
+- Auto-updates cookies returned by responses
 - Tracks metadata (last_update, source, essential flag)
 
 #### 2. Rate Limiting
@@ -320,9 +322,9 @@ If Walmart changes their API:
    - Open DevTools → Network
    - Copy request as cURL
 
-2. **Update GraphQL hashes if needed:**
-   - Hashes are in `orders.go`, `purchases.go`, `ledger.go`
-   - Look for `&extensions=` in endpoint URLs
+2. **Refresh the stored request profile:**
+   - Run `walmart-cli -init curl.txt` so the current `getOrder` hash and browser headers are captured
+   - Static fallback hashes are in `orders.go`, `purchases.go`, and `ledger.go`
 
 3. **Update models if response structure changed:**
    - Add/modify types in `models.go`

--- a/internal/cookies/cookie.go
+++ b/internal/cookies/cookie.go
@@ -1,6 +1,7 @@
 package cookies
 
 import (
+	"regexp"
 	"strings"
 	"time"
 )
@@ -13,32 +14,86 @@ type Cookie struct {
 	Essential  bool      `json:"essential"`
 }
 
-// ExtractFromCurl parses cookies from a curl command string.
-func ExtractFromCurl(curlCmd string) map[string]string {
-	cookies := make(map[string]string)
-	lines := strings.Split(curlCmd, "\\\n")
+const (
+	cookieNameAuth = "auth"
+	cookieNameCID  = "CID"
+	cookieNameSPID = "SPID"
+)
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "-b '") || strings.HasPrefix(line, "--cookie '") {
-			start := strings.Index(line, "'") + 1
-			end := strings.LastIndex(line, "'")
-			if start > 0 && end > start {
-				cookieString := line[start:end]
-				pairs := strings.Split(cookieString, "; ")
-				for _, pair := range pairs {
-					parts := strings.SplitN(pair, "=", 2)
-					if len(parts) == 2 {
-						cookies[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-					}
-				}
-			}
+// CurlCapture contains the request metadata that can be safely reused from a
+// browser's "Copy as cURL" output. Cookie credentials are kept separate from
+// ordinary headers so callers cannot accidentally persist them as profile
+// headers or log them with request diagnostics.
+type CurlCapture struct {
+	URL     string
+	Headers map[string]string
+	Cookies map[string]string
+}
+
+var (
+	curlURLPattern    = regexp.MustCompile(`(?m)\bcurl\s+'([^']+)'`)
+	curlHeaderPattern = regexp.MustCompile(`(?m)(?:^|\s)(?:-H|--header)\s+'([^']+)'`)
+	curlCookiePattern = regexp.MustCompile(`(?m)(?:^|\s)(?:-b|--cookie)\s+'([^']*)'`)
+)
+
+// ParseCurl parses the URL, headers, and cookies from a Chromium-style
+// "Copy as cURL (bash)" command. Header names are normalized to lower case.
+func ParseCurl(curlCmd string) CurlCapture {
+	capture := CurlCapture{
+		Headers: make(map[string]string),
+		Cookies: make(map[string]string),
+	}
+
+	if match := curlURLPattern.FindStringSubmatch(curlCmd); len(match) == 2 {
+		capture.URL = match[1]
+	}
+
+	for _, match := range curlHeaderPattern.FindAllStringSubmatch(curlCmd, -1) {
+		if len(match) != 2 {
+			continue
+		}
+		name, value, ok := strings.Cut(match[1], ":")
+		if !ok {
+			continue
+		}
+		name = strings.ToLower(strings.TrimSpace(name))
+		value = strings.TrimSpace(value)
+		if name == "cookie" {
+			parseCookiePairs(value, capture.Cookies)
+			continue
+		}
+		capture.Headers[name] = value
+	}
+
+	for _, match := range curlCookiePattern.FindAllStringSubmatch(curlCmd, -1) {
+		if len(match) == 2 {
+			parseCookiePairs(match[1], capture.Cookies)
 		}
 	}
-	return cookies
+
+	return capture
+}
+
+// ExtractFromCurl parses cookies from a curl command string.
+func ExtractFromCurl(curlCmd string) map[string]string {
+	return ParseCurl(curlCmd).Cookies
+}
+
+func parseCookiePairs(cookieString string, target map[string]string) {
+	for _, pair := range strings.Split(cookieString, ";") {
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		target[name] = strings.TrimSpace(value)
+	}
 }
 
 // Essential returns list of essential cookie names for authentication.
 func Essential() []string {
-	return []string{"CID", "SPID", "auth", "customer", "hasCID", "type"}
+	return []string{cookieNameCID, cookieNameSPID, cookieNameAuth, "customer", "hasCID", "type"}
 }

--- a/internal/cookies/store.go
+++ b/internal/cookies/store.go
@@ -2,19 +2,31 @@ package cookies
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
 
+// RequestProfile stores the browser request fingerprint captured alongside
+// Walmart session cookies. Headers are intentionally limited by the caller to
+// non-cookie values that are safe and useful to replay.
+type RequestProfile struct {
+	GetOrderHash string            `json:"get_order_hash,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+}
+
 // Store manages cookies with persistence and auto-updates.
 type Store struct {
-	Cookies    map[string]*Cookie `json:"cookies"`
-	LastUpdate time.Time          `json:"last_update"`
-	FilePath   string             `json:"-"`
-	mu         sync.RWMutex
-	logger     *slog.Logger
+	Cookies        map[string]*Cookie `json:"cookies"`
+	LastUpdate     time.Time          `json:"last_update"`
+	RequestProfile *RequestProfile    `json:"request_profile,omitempty"`
+	FilePath       string             `json:"-"`
+	mu             sync.RWMutex
+	logger         *slog.Logger
 }
 
 // NewStore creates a new cookie store.
@@ -39,6 +51,30 @@ func (s *Store) Set(name string, cookie *Cookie) {
 	defer s.mu.Unlock()
 	s.Cookies[name] = cookie
 	s.LastUpdate = time.Now()
+}
+
+// Replace atomically swaps the current browser cookie snapshot and request
+// profile in memory. It is used for explicit browser refreshes so cookies from
+// older captures cannot leak into the new session.
+func (s *Store) Replace(replacement map[string]*Cookie, profile RequestProfile) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Cookies = cloneCookies(replacement)
+	profileCopy := cloneRequestProfile(profile)
+	s.RequestProfile = &profileCopy
+	s.LastUpdate = time.Now()
+}
+
+// GetRequestProfile returns a copy of the captured browser request profile.
+func (s *Store) GetRequestProfile() RequestProfile {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.RequestProfile == nil {
+		return RequestProfile{}
+	}
+	return cloneRequestProfile(*s.RequestProfile)
 }
 
 // Load reads cookies from disk.
@@ -66,6 +102,9 @@ func (s *Store) Load() error {
 		}
 		return err
 	}
+	if s.Cookies == nil {
+		s.Cookies = make(map[string]*Cookie)
+	}
 
 	if s.logger != nil {
 		s.logger.Debug("cookies loaded",
@@ -79,8 +118,6 @@ func (s *Store) Load() error {
 // Save writes cookies to disk.
 func (s *Store) Save() error {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	if s.logger != nil {
 		s.logger.Debug("saving cookies",
 			slog.String("file_path", s.FilePath),
@@ -88,6 +125,7 @@ func (s *Store) Save() error {
 	}
 
 	data, err := json.MarshalIndent(s, "", "  ")
+	s.mu.RUnlock()
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("failed to marshal cookies",
@@ -97,14 +135,50 @@ func (s *Store) Save() error {
 		return err
 	}
 
-	// Cookie files contain session credentials, so restrict to owner read/write.
-	if err := os.WriteFile(s.FilePath, data, 0600); err != nil {
+	// Write to a new owner-only file and rename it into place. Besides avoiding
+	// partially written JSON, replacement fixes permissions on legacy files
+	// that were previously created as group/world-readable.
+	dir := filepath.Dir(s.FilePath)
+	tmp, err := os.CreateTemp(dir, ".cookies-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary cookie file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	tmpClosed := false
+	defer func() {
+		if !tmpClosed {
+			if closeErr := tmp.Close(); closeErr != nil && s.logger != nil {
+				s.logger.Debug("failed to close temporary cookie file", slog.String("error", closeErr.Error()))
+			}
+		}
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) && s.logger != nil {
+			s.logger.Debug("failed to remove temporary cookie file", slog.String("error", removeErr.Error()))
+		}
+	}()
+
+	if err := tmp.Chmod(0600); err != nil {
+		return fmt.Errorf("secure temporary cookie file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write temporary cookie file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync temporary cookie file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary cookie file: %w", err)
+	}
+	tmpClosed = true
+	if err := os.Rename(tmpPath, s.FilePath); err != nil {
 		if s.logger != nil {
 			s.logger.Error("failed to write cookie file",
 				slog.String("file_path", s.FilePath),
 				slog.String("error", err.Error()))
 		}
 		return err
+	}
+	if err := os.Chmod(s.FilePath, 0600); err != nil {
+		return fmt.Errorf("secure cookie file: %w", err)
 	}
 
 	if s.logger != nil {
@@ -131,4 +205,27 @@ func (s *Store) GetAll() map[string]*Cookie {
 		snapshot[k] = v
 	}
 	return snapshot
+}
+
+func cloneCookies(source map[string]*Cookie) map[string]*Cookie {
+	clone := make(map[string]*Cookie, len(source))
+	for name, cookie := range source {
+		if cookie == nil {
+			continue
+		}
+		cookieCopy := *cookie
+		clone[name] = &cookieCopy
+	}
+	return clone
+}
+
+func cloneRequestProfile(profile RequestProfile) RequestProfile {
+	clone := RequestProfile{
+		GetOrderHash: profile.GetOrderHash,
+		Headers:      make(map[string]string, len(profile.Headers)),
+	}
+	for name, value := range profile.Headers {
+		clone.Headers[name] = value
+	}
+	return clone
 }

--- a/ledger.go
+++ b/ledger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -91,7 +92,7 @@ func (c *WalmartClient) GetOrderLedger(ctx context.Context, orderID string) (*Or
 
 	// Build variables JSON and properly URL-encode it.
 	variables := map[string]string{
-		"orderId": orderID,
+		graphqlOrderIDVariable: orderID,
 	}
 	variablesJSON, err := json.Marshal(variables)
 	if err != nil {
@@ -173,7 +174,7 @@ func (c *WalmartClient) fetchLedgerAttempt(ctx context.Context, endpoint, orderI
 	}
 
 	// Set headers.
-	c.setHeaders(req, "getOrderLedger")
+	c.setHeaders(req, "getOrderLedger", buildOrderPageURL(orderID, "0"))
 
 	// Set cookies from store.
 	c.setCookies(req)
@@ -211,6 +212,16 @@ func (c *WalmartClient) fetchLedgerAttempt(ctx context.Context, endpoint, orderI
 
 	// Handle other non-OK statuses (don't retry).
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == 456 {
+			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 129))
+			if readErr != nil {
+				c.logger.Debug("failed to read bot challenge reference", slog.String("error", readErr.Error()))
+			}
+			c.logger.Warn("bot challenge",
+				slog.String("order_id", orderID),
+				slog.Int("status_code", resp.StatusCode))
+			return nil, false, botChallengeError(body)
+		}
 		if resp.StatusCode == 403 || resp.StatusCode == 418 {
 			c.logger.Warn("access denied",
 				slog.String("order_id", orderID),

--- a/orders.go
+++ b/orders.go
@@ -2,7 +2,11 @@ package walmart
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,9 +20,52 @@ import (
 
 const contentTypeJSON = "application/json"
 
+const (
+	cookieNameAuth         = "auth"
+	cookieNameCID          = "CID"
+	cookieNameSPID         = "SPID"
+	defaultGetOrderHash    = "0d0e73dcfbe4c7a4cb6c8ce929e5b9a8b3e731e4bac81969eed76dbdab28b0d2"
+	defaultPlatform        = "usweb-1.284.0-1871dae08edcd429b12e47a369da9967df5b330d-7141058r"
+	defaultUserAgent       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+	graphqlOrderIDVariable = "orderId"
+	headerPlatformVersion  = "x-o-platform-version"
+	headerUserAgent        = "user-agent"
+)
+
+// ErrBotChallenge identifies Walmart's non-standard HTTP 456 response. It
+// means the request was rejected by bot protection and the browser session
+// profile should be refreshed before retrying.
+var ErrBotChallenge = errors.New("walmart rejected request as automated")
+
+var requestProfileHeaderAllowlist = map[string]struct{}{
+	"cache-control":         {},
+	"device-memory":         {},
+	"device_profile_ref_id": {},
+	"downlink":              {},
+	"dpr":                   {},
+	"pragma":                {},
+	"priority":              {},
+	"sec-ch-device-memory":  {},
+	"sec-ch-dpr":            {},
+	"sec-ch-ua":             {},
+	"sec-ch-ua-mobile":      {},
+	"sec-ch-ua-platform":    {},
+	"tenant-id":             {},
+	headerUserAgent:         {},
+	"x-o-ccm":               {},
+	headerPlatformVersion:   {},
+}
+
 // GetOrder fetches an order with automatic cookie updates.
 // The context can be used to cancel the request or set a deadline.
 func (c *WalmartClient) GetOrder(ctx context.Context, orderID string, isInStore bool) (*Order, error) {
+	return c.GetOrderWithGroup(ctx, orderID, "0", isInStore)
+}
+
+// GetOrderWithGroup fetches an order using the group identifier returned by
+// purchase history. Walmart's web client includes this identifier in both the
+// GraphQL variables and order-page request context.
+func (c *WalmartClient) GetOrderWithGroup(ctx context.Context, orderID, groupID string, isInStore bool) (*Order, error) {
 	// Rate limiting with context support.
 	if !c.lastRequest.IsZero() {
 		c.logger.Debug("waiting for rate limiter")
@@ -31,7 +78,7 @@ func (c *WalmartClient) GetOrder(ctx context.Context, orderID string, isInStore 
 	}
 	c.lastRequest = time.Now()
 
-	endpoint := c.buildOrderEndpoint(orderID, isInStore)
+	endpoint := c.buildOrderEndpointWithGroup(orderID, groupID, isInStore)
 
 	c.logger.Debug("fetching order",
 		slog.String("order_id", orderID),
@@ -47,7 +94,7 @@ func (c *WalmartClient) GetOrder(ctx context.Context, orderID string, isInStore 
 	}
 
 	// Set headers.
-	c.setHeaders(req, "getOrder")
+	c.setHeaders(req, "getOrder", buildOrderPageURL(orderID, groupID))
 
 	// Set cookies from store.
 	c.setCookies(req)
@@ -160,6 +207,11 @@ func (c *WalmartClient) checkOrderResponseError(resp *http.Response, body []byte
 			slog.String("order_id", orderID),
 			slog.Int("status_code", resp.StatusCode))
 		return fmt.Errorf("access denied - cookies expired, please update from browser")
+	case 456:
+		c.logger.Warn("bot challenge",
+			slog.String("order_id", orderID),
+			slog.Int("status_code", resp.StatusCode))
+		return botChallengeError(body)
 	default:
 		c.logger.Warn("non-200 response",
 			slog.String("order_id", orderID),
@@ -175,6 +227,9 @@ func (c *WalmartClient) GetOrderAutoDetect(ctx context.Context, orderID string) 
 	order, err := c.GetOrder(ctx, orderID, true)
 	if err == nil {
 		return order, nil
+	}
+	if errors.Is(err, ErrBotChallenge) {
+		return nil, err
 	}
 
 	// Check for cancellation before retrying.
@@ -242,15 +297,22 @@ func (c *WalmartClient) GetOrderAsJSON(ctx context.Context, orderID string, isIn
 
 // buildOrderEndpoint constructs the GraphQL endpoint URL for fetching order details.
 func (c *WalmartClient) buildOrderEndpoint(orderID string, isInStore bool) string {
+	return c.buildOrderEndpointWithGroup(orderID, "0", isInStore)
+}
+
+func (c *WalmartClient) buildOrderEndpointWithGroup(orderID, groupID string, isInStore bool) string {
 	variables := map[string]interface{}{
-		"orderId":              orderID,
-		"orderIsInStore":       isInStore,
-		"clickThroughGroupId":  "0",
-		"enableIsWcpOrder":     false,
-		"enabledFeatures":      []string{"csat-northstar-v1", "tips", "delivery-fees"},
-		"enableSignOnDelivery": true,
-		"includeTipDetails":    true,
-		"includeFeesDetails":   true,
+		"clickThroughGroupId":       groupID,
+		"eligibleFeatures":          map[string]bool{"isEbtEligible": false, "isLotOnOdpEnable": false},
+		"enableCancelFix":           false,
+		"enableGroupBannerMessages": false,
+		"enableIsWcpOrder":          false,
+		"enableSignOnDelivery":      true,
+		"enableVolumePricing":       false,
+		"enableWcpPhaseOrder":       false,
+		"enabledFeatures":           []string{"csc", "csat-northstar-v1"},
+		graphqlOrderIDVariable:      orderID,
+		"orderIsInStore":            isInStore,
 	}
 
 	variablesJSON, err := json.Marshal(variables)
@@ -260,38 +322,97 @@ func (c *WalmartClient) buildOrderEndpoint(orderID string, isInStore bool) strin
 	params := url.Values{}
 	params.Set("variables", string(variablesJSON))
 
-	return fmt.Sprintf("https://www.walmart.com/orchestra/orders/graphql/getOrder/d0622497daef19150438d07c506739d451cad6749cf45c3b4db95f2f5a0a65c4?%s",
-		params.Encode())
+	hash := defaultGetOrderHash
+	if profileHash := c.cookieStore.GetRequestProfile().GetOrderHash; profileHash != "" {
+		hash = profileHash
+	}
+
+	return fmt.Sprintf("https://www.walmart.com/orchestra/orders/graphql/getOrder/%s?%s", hash, params.Encode())
 }
 
 // setHeaders sets standard HTTP headers required by Walmart's API.
-func (c *WalmartClient) setHeaders(req *http.Request, operationName string) {
+func (c *WalmartClient) setHeaders(req *http.Request, operationName, pageURL string) {
 	headers := map[string]string{
 		"accept":                  contentTypeJSON,
-		"accept-language":         "en-US",
+		"accept-language":         "en-US,en;q=0.9",
 		"content-type":            contentTypeJSON,
-		"user-agent":              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+		headerUserAgent:           defaultUserAgent,
 		"x-apollo-operation-name": operationName,
 		"x-o-gql-query":           fmt.Sprintf("query %s", operationName),
 		"x-o-platform":            "rweb",
 		"x-o-bu":                  "WALMART-US",
 		"x-o-mart":                "B2C",
 		"x-o-segment":             "oaoh",
-		"x-o-correlation-id":      fmt.Sprintf("walmart-go-%d", time.Now().Unix()),
-		"wm_qos.correlation_id":   fmt.Sprintf("walmart-go-%d", time.Now().Unix()),
 		"wm_mp":                   "true",
 		"sec-fetch-site":          "same-origin",
 		"sec-fetch-mode":          "cors",
 		"sec-fetch-dest":          "empty",
-		"dnt":                     "1",
-		"x-o-platform-version":    "usweb-1.221.0",
+		"sec-ch-ua-mobile":        "?0",
+		"sec-ch-ua-platform":      `"macOS"`,
+		headerPlatformVersion:     defaultPlatform,
 		"x-enable-server-timing":  "1",
 		"x-latency-trace":         "1",
+	}
+
+	profile := c.cookieStore.GetRequestProfile()
+	for name, value := range profile.Headers {
+		if _, ok := requestProfileHeaderAllowlist[name]; ok {
+			headers[name] = value
+		}
+	}
+
+	correlationID := randomUUID()
+	headers["x-o-correlation-id"] = correlationID
+	headers["wm_qos.correlation_id"] = correlationID
+	headers["wm-client-traceid"] = randomHex(16)
+	headers["traceparent"] = fmt.Sprintf("00-%s-%s-01", randomHex(16), randomHex(8))
+	if pageURL != "" {
+		headers["referer"] = pageURL
+		headers["wm_page_url"] = pageURL
 	}
 
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+}
+
+func buildOrderPageURL(orderID, groupID string) string {
+	query := url.Values{}
+	query.Set("groupId", groupID)
+	return fmt.Sprintf("https://www.walmart.com/orders/%s?%s", url.PathEscape(orderID), query.Encode())
+}
+
+func botChallengeError(body []byte) error {
+	reference := strings.TrimSpace(string(body))
+	if len(reference) > 128 {
+		reference = reference[:128]
+	}
+	if reference == "" {
+		return fmt.Errorf("%w: HTTP 456; refresh cookies and the request profile from a browser", ErrBotChallenge)
+	}
+	return fmt.Errorf("%w: HTTP 456 (reference %s); refresh cookies and the request profile from a browser", ErrBotChallenge, reference)
+}
+
+func randomUUID() string {
+	b := randomBytes(16)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	encoded := hex.EncodeToString(b)
+	return fmt.Sprintf("%s-%s-%s-%s-%s", encoded[0:8], encoded[8:12], encoded[12:16], encoded[16:20], encoded[20:32])
+}
+
+func randomHex(byteCount int) string {
+	return hex.EncodeToString(randomBytes(byteCount))
+}
+
+func randomBytes(size int) []byte {
+	b := make([]byte, size)
+	if _, err := rand.Read(b); err == nil {
+		return b
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d", time.Now().UnixNano())))
+	copy(b, sum[:])
+	return b
 }
 
 // setCookies adds all cookies from the store to the request.

--- a/orders_test.go
+++ b/orders_test.go
@@ -5,9 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/eshaffer321/walmart-client-go/v2/internal/cookies"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,6 +152,96 @@ func TestGetOrderStatusErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErrMsg)
 		})
 	}
+}
+
+func TestGetOrderHTTP456IsBotChallenge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(456)
+		_, _ = w.Write([]byte("opaque-reference-id"))
+	}))
+	defer server.Close()
+
+	client := newMockClient(t, server.URL)
+	_, err := client.GetOrder(context.Background(), "x", true)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBotChallenge)
+	assert.Contains(t, err.Error(), "HTTP 456")
+}
+
+func TestGetOrderAutoDetectDoesNotRetryBotChallenge(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		w.WriteHeader(456)
+		_, _ = w.Write([]byte("opaque-reference-id"))
+	}))
+	defer server.Close()
+
+	client := newMockClient(t, server.URL)
+	_, err := client.GetOrderAutoDetect(context.Background(), "x")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBotChallenge)
+	assert.Equal(t, 1, requestCount)
+}
+
+func TestGetOrderWithGroupUsesCapturedBrowserProfile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/getOrder/0d0e73dcfbe4c7a4cb6c8ce929e5b9a8b3e731e4bac81969eed76dbdab28b0d2")
+
+		var variables map[string]any
+		require.NoError(t, json.Unmarshal([]byte(r.URL.Query().Get("variables")), &variables))
+		assert.Equal(t, "group-123", variables["clickThroughGroupId"])
+		assert.Equal(t, []any{"csc", "csat-northstar-v1"}, variables["enabledFeatures"])
+		assert.NotContains(t, variables, "includeTipDetails")
+		assert.NotContains(t, variables, "includeFeesDetails")
+
+		assert.Equal(t, testCapturedUserAgent, r.Header.Get("User-Agent"))
+		assert.Equal(t, `"Chromium";v="149"`, r.Header.Get("sec-ch-ua"))
+		assert.Equal(t, testCapturedPlatform, r.Header.Get(headerPlatformVersion))
+		assert.Equal(t, "tenant", r.Header.Get("tenant-id"))
+		assert.Equal(t, "ccm-id", r.Header.Get("x-o-ccm"))
+		assert.Equal(t, r.Header.Get("Referer"), r.Header.Get("wm_page_url"))
+		assert.Contains(t, r.Header.Get("Referer"), "/orders/order-123?groupId=group-123")
+		assert.Empty(t, r.Header.Get("dnt"))
+
+		assert.Equal(t, r.Header.Get("x-o-correlation-id"), r.Header.Get("wm_qos.correlation_id"))
+		assert.NotContains(t, r.Header.Get("x-o-correlation-id"), "walmart-go")
+		assert.Len(t, r.Header.Get("wm-client-traceid"), 32)
+		assert.True(t, strings.HasPrefix(r.Header.Get("traceparent"), "00-"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(inStoreOrderJSON))
+	}))
+	defer server.Close()
+
+	client := newMockClient(t, server.URL)
+	client.cookieStore.Replace(map[string]*cookies.Cookie{
+		cookieNameCID: {Value: testSource},
+	}, cookies.RequestProfile{
+		GetOrderHash: "0d0e73dcfbe4c7a4cb6c8ce929e5b9a8b3e731e4bac81969eed76dbdab28b0d2",
+		Headers: map[string]string{
+			headerUserAgent:       testCapturedUserAgent,
+			"sec-ch-ua":           `"Chromium";v="149"`,
+			headerPlatformVersion: testCapturedPlatform,
+			"tenant-id":           "tenant",
+			"x-o-ccm":             "ccm-id",
+		},
+	})
+
+	order, err := client.GetOrderWithGroup(context.Background(), "order-123", "group-123", true)
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	assert.Equal(t, "200013509224581", order.ID)
+}
+
+func TestBuildOrderPageURL(t *testing.T) {
+	pageURL := buildOrderPageURL("order/with spaces", "group&value")
+	parsed, err := url.Parse(pageURL)
+	require.NoError(t, err)
+	assert.Equal(t, "/orders/order%2Fwith%20spaces", parsed.EscapedPath())
+	assert.Equal(t, "group&value", parsed.Query().Get("groupId"))
 }
 
 func TestGetOrderMalformedJSON(t *testing.T) {

--- a/purchases.go
+++ b/purchases.go
@@ -199,6 +199,9 @@ func (c *WalmartClient) checkPurchaseResponseError(resp *http.Response, body []b
 	case 403, 418:
 		c.logger.Warn("access denied", slog.Int("status_code", resp.StatusCode))
 		return fmt.Errorf("access denied - cookies expired, please update from browser")
+	case 456:
+		c.logger.Warn("bot challenge", slog.Int("status_code", resp.StatusCode))
+		return botChallengeError(body)
 	default:
 		c.logger.Warn("non-200 response", slog.Int("status_code", resp.StatusCode))
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
@@ -320,30 +323,5 @@ func (c *WalmartClient) buildPurchaseHistoryEndpoint(req PurchaseHistoryRequest)
 
 // Set headers specific to purchase history.
 func (c *WalmartClient) setPurchaseHistoryHeaders(req *http.Request) {
-	headers := map[string]string{
-		"accept":                  contentTypeJSON,
-		"accept-language":         "en-US",
-		"content-type":            contentTypeJSON,
-		"user-agent":              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
-		"x-apollo-operation-name": "PurchaseHistoryV2",
-		"x-o-gql-query":           "query PurchaseHistoryV2",
-		"x-o-platform":            "rweb",
-		"x-o-bu":                  "WALMART-US",
-		"x-o-mart":                "B2C",
-		"x-o-segment":             "oaoh",
-		"x-o-correlation-id":      fmt.Sprintf("walmart-go-%d", time.Now().Unix()),
-		"wm_qos.correlation_id":   fmt.Sprintf("walmart-go-%d", time.Now().Unix()),
-		"wm_mp":                   "true",
-		"sec-fetch-site":          "same-origin",
-		"sec-fetch-mode":          "cors",
-		"sec-fetch-dest":          "empty",
-		"dnt":                     "1",
-		"x-o-platform-version":    "usweb-1.221.0",
-		"x-enable-server-timing":  "1",
-		"x-latency-trace":         "1",
-	}
-
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
+	c.setHeaders(req, "PurchaseHistoryV2", "https://www.walmart.com/orders")
 }

--- a/session_profile_test.go
+++ b/session_profile_test.go
@@ -1,0 +1,65 @@
+package walmart
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eshaffer321/walmart-client-go/v2/internal/cookies"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCapturedPlatform  = "usweb-1.284.0-test"
+	testCapturedUserAgent = "Mozilla/5.0 Chrome/149.0.0.0"
+)
+
+func TestParseCurlCapturesRequestProfileWithoutCookieHeader(t *testing.T) {
+	curlCmd := "curl 'https://www.walmart.com/orchestra/orders/graphql/getOrder/" +
+		defaultGetOrderHash + "?variables=%7B%7D' \\\n" +
+		"  -H 'user-agent: Mozilla/5.0 Chrome/149.0.0.0' \\\n" +
+		"  -H 'sec-ch-ua: \"Chromium\";v=\"149\"' \\\n" +
+		"  -H 'x-o-platform-version: usweb-1.284.0-test' \\\n" +
+		"  -H 'cookie: CID=abc; SPID=xyz; auth=token'"
+
+	capture := cookies.ParseCurl(curlCmd)
+
+	assert.Contains(t, capture.URL, "/getOrder/"+defaultGetOrderHash)
+	assert.Equal(t, testCapturedUserAgent, capture.Headers[headerUserAgent])
+	assert.Equal(t, `"Chromium";v="149"`, capture.Headers["sec-ch-ua"])
+	assert.Equal(t, testCapturedPlatform, capture.Headers[headerPlatformVersion])
+	assert.Equal(t, map[string]string{cookieNameCID: "abc", cookieNameSPID: "xyz", cookieNameAuth: "token"}, capture.Cookies)
+	assert.NotContains(t, capture.Headers, "cookie", "cookie credentials must not be retained as profile headers")
+}
+
+func TestCookieStoreReplacePersistsProfileAndResecuresFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cookies.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"cookies":{}}`), 0644))
+	require.NoError(t, os.Chmod(path, 0644))
+
+	store := cookies.NewStore(path, nil)
+	store.Set("stale", &cookies.Cookie{Value: "old"})
+	profile := cookies.RequestProfile{
+		GetOrderHash: defaultGetOrderHash,
+		Headers: map[string]string{
+			headerUserAgent:       testCapturedUserAgent,
+			headerPlatformVersion: testCapturedPlatform,
+		},
+	}
+	store.Replace(map[string]*cookies.Cookie{
+		cookieNameCID: {Value: "new", Essential: true},
+	}, profile)
+	require.NoError(t, store.Save())
+
+	loaded := cookies.NewStore(path, nil)
+	require.NoError(t, loaded.Load())
+	assert.Nil(t, loaded.Get("stale"))
+	assert.Equal(t, "new", loaded.Get(cookieNameCID).Value)
+	assert.Equal(t, profile, loaded.GetRequestProfile())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}


### PR DESCRIPTION
## What

- capture the live getOrder persisted-query hash and allowlisted browser request profile from Copy as cURL
- replace stale cookie snapshots during refresh and save them atomically with mode 0600
- add GetOrderWithGroup and pass the purchase-history group ID through the request
- update getOrder variables, browser headers, and per-request trace and correlation IDs
- expose ErrBotChallenge for HTTP 456 and stop auto-detect from repeating a challenged request
- document the v2.2.0 behavior and migration path

## Why

The client replayed an obsolete GraphQL hash and variable set, a hard-coded Chrome 139 and usweb profile, and a synthetic correlation ID. Refresh also merged browser cookies, leaving expired WAF state from older sessions. Walmart accepted purchase-history calls but rejected detail calls with HTTP 456.

## Verification

- make pre-commit: format, golangci-lint, and race-enabled tests
- make build
- make vet
- gosec ./...
- live read-only getOrder using an isolated store and the captured order and group ID: success, 17 items