### PR TITLE
fix: preserve response cookie paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-07-15
+
+### Fixed
+- Response cookies now retain their domain and path scope in an in-memory cookie jar instead of overwriting the persistent browser snapshot. This prevents purchase-history cookies from poisoning subsequent order-detail requests with HTTP 456.
+
 ## [2.2.0] - 2026-07-15
 
 ### Added
@@ -262,7 +267,8 @@ git push origin v1.0.3
 gh release create v1.0.3 --generate-notes
 ```
 
-[Unreleased]: https://github.com/eshaffer321/walmart-client-go/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/eshaffer321/walmart-client-go/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/eshaffer321/walmart-client-go/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/eshaffer321/walmart-client-go/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/eshaffer321/walmart-client-go/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/eshaffer321/walmart-client-go/compare/v2.0.1...v2.0.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Available as both a **Go library** for programmatic access and a **CLI tool** fo
 - 💳 **NEW:** Order ledger API for payment tracking - match orders to bank transactions
 - 🔍 Search orders for specific items
 - 📄 Pagination support for large order histories
-- 🍪 Automatic cookie management with rotation to prevent staleness
+- 🍪 Path-aware response cookie handling without corrupting the captured browser session
 - 💾 Persistent cookie storage in `~/.walmart-api/cookies.json`
 
 ## Installation
@@ -389,7 +389,7 @@ This saves the current browser cookie snapshot, `getOrder` query hash, and safe 
 - Replays the complete cookie snapshot from your current browser session
 - Captures the live `getOrder` hash and browser request profile instead of hard-coding a stale fingerprint
 - Replaces old cookies on refresh so expired WAF state cannot leak into the new session
-- Automatically incorporates cookie updates returned by Walmart
+- Keeps response cookie updates in a path-aware in-memory jar so one endpoint cannot poison another
 
 ### API Endpoints
 
@@ -462,7 +462,7 @@ Cookies are stored in `~/.walmart-api/cookies.json` with metadata:
 
 ### Rate Limiting
 - Built-in 2-second delay between requests
-- Automatic cookie updates to prevent staleness
+- Path-aware, in-memory response cookie updates preserve the persistent browser snapshot
 - Proper error handling for rate limits (429) and bot detection (418/456)
 
 ### GraphQL Persisted Queries

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -22,6 +23,7 @@ var getOrderHashPattern = regexp.MustCompile(`/orchestra/orders/graphql/getOrder
 type WalmartClient struct {
 	httpClient        *http.Client
 	cookieStore       *cookies.Store
+	responseCookieJar *cookiejar.Jar
 	rateLimiter       *time.Ticker
 	ledgerRateLimiter *time.Ticker
 	lastRequest       time.Time
@@ -84,6 +86,11 @@ func NewWalmartClient(config ClientConfig) (*WalmartClient, error) {
 		logger.Debug("no existing cookies found", slog.String("file_path", config.CookieFile))
 	}
 
+	responseCookieJar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize response cookie jar: %w", err)
+	}
+
 	client := &WalmartClient{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
@@ -93,6 +100,7 @@ func NewWalmartClient(config ClientConfig) (*WalmartClient, error) {
 			},
 		},
 		cookieStore:       store,
+		responseCookieJar: responseCookieJar,
 		rateLimiter:       time.NewTicker(config.RateLimit),
 		ledgerRateLimiter: time.NewTicker(ledgerRate),
 		maxRetries:        maxRetries,
@@ -158,7 +166,14 @@ func (c *WalmartClient) InitializeFromCurl(curlFile string) error {
 
 	// A browser refresh is a coherent session snapshot. Replace instead of
 	// merging so expired WAF cookies from an older capture cannot survive.
+	responseCookieJar, err := cookiejar.New(nil)
+	if err != nil {
+		return fmt.Errorf("failed to reset response cookie jar: %w", err)
+	}
+	c.mu.Lock()
 	c.cookieStore.Replace(replacement, profile)
+	c.responseCookieJar = responseCookieJar
+	c.mu.Unlock()
 
 	// Auto-save.
 	if err := c.cookieStore.Save(); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -176,6 +176,7 @@ func TestUpdateCookiesFromResponse(t *testing.T) {
 
 	// Create mock response with Set-Cookie headers.
 	resp := &http.Response{
+		Request: &http.Request{URL: mustParseURL(t, "https://www.walmart.com/orchestra/orders/graphql/getOrder/hash")},
 		Header: http.Header{
 			"Set-Cookie": []string{
 				"existing=new_value; Path=/",
@@ -186,20 +187,34 @@ func TestUpdateCookiesFromResponse(t *testing.T) {
 
 	client.updateCookiesFromResponse(resp)
 
-	// Check existing cookie was updated.
-	existing := client.cookieStore.Get("existing")
-	if existing == nil || existing.Value != "new_value" {
-		t.Error("Failed to update existing cookie")
+	request, err := http.NewRequest(http.MethodGet, "https://www.walmart.com/orchestra/orders/graphql/getOrder/next", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
 	}
-	if !existing.Essential {
-		t.Error("Lost essential flag on update")
+	client.setCookies(request)
+	values := requestCookieValues(request)
+	if values["existing"] != "new_value" {
+		t.Error("Failed to apply response cookie to a matching request path")
 	}
-
-	// Check new cookie was added.
-	newCookie := client.cookieStore.Get("new_cookie")
-	if newCookie == nil || newCookie.Value != "value" {
+	if values["new_cookie"] != "value" {
 		t.Error("Failed to add new cookie from response")
 	}
+
+	// The persistent browser snapshot remains unchanged; response cookies are
+	// path-aware and in-memory only.
+	existing := client.cookieStore.Get("existing")
+	if existing == nil || existing.Value != "old_value" || !existing.Essential {
+		t.Error("Response cookie mutated persistent browser snapshot")
+	}
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL: %v", err)
+	}
+	return parsed
 }
 
 func TestBuildOrderEndpoint(t *testing.T) {

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -48,7 +48,7 @@ Walmart requires a coherent cookie snapshot and request profile from the same br
 - Persists to `~/.walmart-api/cookies.json`
 - Replaces the previous snapshot when importing a fresh `getOrder` cURL request
 - Persists the active GraphQL hash and allowlisted browser headers
-- Auto-updates cookies returned by responses
+- Keeps cookies returned by responses in a path-aware in-memory jar; they never flatten into or overwrite the persistent browser snapshot
 - Tracks metadata (last_update, source, essential flag)
 
 #### 2. Rate Limiting

--- a/orders.go
+++ b/orders.go
@@ -12,10 +12,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
-
-	"github.com/eshaffer321/walmart-client-go/v2/internal/cookies"
 )
 
 const contentTypeJSON = "application/json"
@@ -422,7 +421,23 @@ func (c *WalmartClient) setCookies(req *http.Request) {
 
 	allCookies := c.cookieStore.GetAll()
 	cookiePairs := make([]string, 0, len(allCookies))
-	for name, cookie := range allCookies {
+	responseCookieNames := make(map[string]bool)
+	if c.responseCookieJar != nil {
+		for _, cookie := range c.responseCookieJar.Cookies(req.URL) {
+			cookiePairs = append(cookiePairs, fmt.Sprintf("%s=%s", cookie.Name, cookie.Value))
+			responseCookieNames[cookie.Name] = true
+		}
+	}
+
+	baseCookieNames := make([]string, 0, len(allCookies))
+	for name := range allCookies {
+		if !responseCookieNames[name] {
+			baseCookieNames = append(baseCookieNames, name)
+		}
+	}
+	sort.Strings(baseCookieNames)
+	for _, name := range baseCookieNames {
+		cookie := allCookies[name]
 		cookiePairs = append(cookiePairs, fmt.Sprintf("%s=%s", name, cookie.Value))
 	}
 
@@ -433,41 +448,21 @@ func (c *WalmartClient) setCookies(req *http.Request) {
 
 // updateCookiesFromResponse updates cookie store with Set-Cookie headers.
 func (c *WalmartClient) updateCookiesFromResponse(resp *http.Response) {
-	setCookies := resp.Header["Set-Cookie"]
-	if len(setCookies) == 0 {
+	responseCookies := resp.Cookies()
+	if len(responseCookies) == 0 {
+		return
+	}
+	if resp.Request == nil || resp.Request.URL == nil {
+		c.logger.Debug("cannot retain response cookies without request URL")
 		return
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	updatedCount := 0
-	for _, cookieHeader := range setCookies {
-		parts := strings.Split(cookieHeader, ";")
-		if len(parts) > 0 {
-			nameValue := strings.SplitN(parts[0], "=", 2)
-			if len(nameValue) == 2 {
-				name := strings.TrimSpace(nameValue[0])
-				value := strings.TrimSpace(nameValue[1])
-
-				// Check if this is an update.
-				existing := c.cookieStore.Get(name)
-				if existing != nil && existing.Value != value {
-					updatedCount++
-				}
-
-				c.cookieStore.Set(name, &cookies.Cookie{
-					Value:      value,
-					LastUpdate: time.Now(),
-					Source:     "response",
-					Essential:  existing != nil && existing.Essential,
-				})
-			}
-		}
+	if c.responseCookieJar == nil {
+		return
 	}
-
-	if updatedCount > 0 {
-		c.logger.Debug("cookies updated from response",
-			slog.Int("updated_count", updatedCount))
-	}
+	c.responseCookieJar.SetCookies(resp.Request.URL, responseCookies)
+	c.logger.Debug("response cookies retained in path-aware jar",
+		slog.Int("cookie_count", len(responseCookies)))
 }

--- a/session_profile_test.go
+++ b/session_profile_test.go
@@ -1,6 +1,7 @@
 package walmart
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,4 +63,43 @@ func TestCookieStoreReplacePersistsProfileAndResecuresFile(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestResponseCookiesRespectRequestPath(t *testing.T) {
+	client, err := NewWalmartClient(ClientConfig{CookieFile: filepath.Join(t.TempDir(), "cookies.json")})
+	require.NoError(t, err)
+	client.cookieStore.Set(cookieNameAuth, &cookies.Cookie{Value: "captured-auth"})
+	client.cookieStore.Set("shared", &cookies.Cookie{Value: "captured-shared"})
+
+	historyRequest, err := http.NewRequest(http.MethodGet, "https://www.walmart.com/orchestra/cph/graphql/PurchaseHistoryV2/hash", nil)
+	require.NoError(t, err)
+	response := &http.Response{
+		Request: historyRequest,
+		Header: http.Header{"Set-Cookie": []string{
+			"auth=history-only; Path=/orchestra/cph; Secure",
+			"shared=updated-root; Path=/; Secure",
+		}},
+	}
+	client.updateCookiesFromResponse(response)
+
+	orderRequest, err := http.NewRequest(http.MethodGet, "https://www.walmart.com/orchestra/orders/graphql/getOrder/hash", nil)
+	require.NoError(t, err)
+	client.setCookies(orderRequest)
+	orderCookies := requestCookieValues(orderRequest)
+	assert.Equal(t, "captured-auth", orderCookies[cookieNameAuth], "history-path auth cookie must not poison order requests")
+	assert.Equal(t, "updated-root", orderCookies["shared"])
+
+	nextHistoryRequest, err := http.NewRequest(http.MethodGet, "https://www.walmart.com/orchestra/cph/graphql/PurchaseHistoryV2/hash", nil)
+	require.NoError(t, err)
+	client.setCookies(nextHistoryRequest)
+	historyCookies := requestCookieValues(nextHistoryRequest)
+	assert.Equal(t, "history-only", historyCookies[cookieNameAuth])
+}
+
+func requestCookieValues(req *http.Request) map[string]string {
+	values := make(map[string]string)
+	for _, cookie := range req.Cookies() {
+		values[cookie.Name] = cookie.Value
+	}
+	return values
 }


### PR DESCRIPTION
## What

- keep Set-Cookie updates in a standards-based, path-aware in-memory jar
- leave the persistent browser cookie snapshot unchanged
- prefer path-matching response cookies while retaining captured values for other endpoints
- reset ephemeral response cookies whenever a fresh browser cURL is imported
- document the v2.2.1 fix

## Why

The v2.2.0 functional test exposed a second root cause: PurchaseHistoryV2 rotates auth and WAF cookies with endpoint-specific paths. The old flat name-to-value store discarded path and domain attributes, so a history-only auth cookie overwrote the captured order-session cookie and the next getOrder call received HTTP 456.

## Verification

- regression test proves a history-path auth cookie cannot poison an order-path request
- make pre-commit: format, lint, and race-enabled tests
- make build
- make vet
- gosec ./...
- live sequence with an isolated store: PurchaseHistoryV2 followed by a completed in-store getOrder succeeded with 4 items